### PR TITLE
@WIP Fixed bug where processing occurs on invalid objects

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -109,8 +109,6 @@ module Paperclip
           nil
         else
           assign_attributes
-          post_process_file
-          reset_file_if_original_reprocessed
         end
       else
         nil
@@ -238,6 +236,8 @@ module Paperclip
     # Saves the file, if there are no errors. If there are, it flushes them to
     # the instance's errors and returns false, cancelling the save.
     def save
+      post_process_file
+      reset_file_if_original_reprocessed
       flush_deletes unless @options[:keep_old_files]
       process = only_process
       if process.any? && !process.include?(:original)

--- a/spec/paperclip/attachment_processing_spec.rb
+++ b/spec/paperclip/attachment_processing_spec.rb
@@ -4,34 +4,47 @@ describe 'Attachment Processing' do
   before { rebuild_class }
 
   context 'using validates_attachment_content_type' do
-    it 'processes attachments given a valid assignment' do
+    it "doesn't process attachments on assignment" do
       file = File.new(fixture_file("5k.png"))
       Dummy.validates_attachment_content_type :avatar, content_type: "image/png"
       instance = Dummy.new
       attachment = instance.avatar
-      attachment.expects(:post_process_styles)
+      attachment.expects(:post_process_styles).never
 
       attachment.assign(file)
     end
 
-    it 'does not process attachments given an invalid assignment with :not' do
+    it 'processes attachments given the object is valid' do
+      file = File.new(fixture_file("5k.png"))
+      Dummy.validates_attachment_content_type :avatar, content_type: "image/png"
+      instance = Dummy.new
+      attachment = instance.avatar
+      attachment.assign(file)
+      attachment.expects(:post_process_styles)
+
+      attachment.save
+    end
+
+    it 'does not process attachments given an invalid object with :not' do
       file = File.new(fixture_file("5k.png"))
       Dummy.validates_attachment_content_type :avatar, not: "image/png"
       instance = Dummy.new
       attachment = instance.avatar
+      attachment.assign(file)
       attachment.expects(:post_process_styles).never
 
-      attachment.assign(file)
+      attachment.save
     end
 
-    it 'does not process attachments given an invalid assignment with :content_type' do
+    it 'does not process attachments given an invalid object with :content_type' do
       file = File.new(fixture_file("5k.png"))
       Dummy.validates_attachment_content_type :avatar, content_type: "image/tiff"
       instance = Dummy.new
       attachment = instance.avatar
+      attachment.assign(file)
       attachment.expects(:post_process_styles).never
 
-      attachment.assign(file)
+      attachment.save
     end
 
     it 'allows what would be an invalid assignment when validation :if clause returns false' do
@@ -39,14 +52,15 @@ describe 'Attachment Processing' do
       Dummy.validates_attachment_content_type :avatar, content_type: "image/tiff", if: lambda{false}
       instance = Dummy.new
       attachment = instance.avatar
+      attachment.assign(invalid_assignment)
       attachment.expects(:post_process_styles)
 
-      attachment.assign(invalid_assignment)
+      attachment.save
     end
   end
 
   context 'using validates_attachment' do
-    it 'processes attachments given a valid assignment' do
+    it "doesn't process attachments on assignment" do
       file = File.new(fixture_file("5k.png"))
       Dummy.validates_attachment :avatar, content_type: {content_type: "image/png"}
       instance = Dummy.new
@@ -56,24 +70,37 @@ describe 'Attachment Processing' do
       attachment.assign(file)
     end
 
-    it 'does not process attachments given an invalid assignment with :not' do
+    it 'processes attachments given a valid object' do
+      file = File.new(fixture_file("5k.png"))
+      Dummy.validates_attachment :avatar, content_type: {content_type: "image/png"}
+      instance = Dummy.new
+      attachment = instance.avatar
+      attachment.assign(file)
+      attachment.expects(:post_process_styles)
+
+      attachment.save
+    end
+
+    it 'does not process attachments given an invalid object with :not' do
       file = File.new(fixture_file("5k.png"))
       Dummy.validates_attachment :avatar, content_type: {not: "image/png"}
       instance = Dummy.new
       attachment = instance.avatar
+      attachment.assign(file)
       attachment.expects(:post_process_styles).never
 
-      attachment.assign(file)
+      attachment.save
     end
 
-    it 'does not process attachments given an invalid assignment with :content_type' do
+    it 'does not process attachments given an invalid object with :content_type' do
       file = File.new(fixture_file("5k.png"))
       Dummy.validates_attachment :avatar, content_type: {content_type: "image/tiff"}
       instance = Dummy.new
       attachment = instance.avatar
+      attachment.assign(file)
       attachment.expects(:post_process_styles).never
 
-      attachment.assign(file)
+      attachment.save
     end
   end
 end


### PR DESCRIPTION
- Because the processors were called on assignment, instead of during saving,
  the validations could never work correctly. This is because the built in
  validations use the values in the db columns to operate. However, since these
  are populated on assignment, the validations cannot run before the processors
  run. Moreover, any other type of validation not dependent on the db columns
  also cannot run, because the processors are called on assignment. The
  processors should be called during save which allows for validations to occur.

- Fixed tests that assert the incorrect behavior

- Closes thoughtbot/paperclip#2462, Closes thoughtbot/paperclip#2321, Closes
  thoughtbot/paperclip#2236, Closes thoughtbot/paperclip#2178,
  Closes thoughtbot/paperclip#1960, Closes thoughtbot/paperclip#2204