### PR TITLE
replace mocha with rspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-sudo: false
+# sudo: false
 
 rvm:
   - 2.1
@@ -16,7 +16,12 @@ addons:
     - libjpeg-dev
     - libpng-dev
     - libgif-dev
-    - ghostscript
+    - ghostscript-9.20
+
+before_install:
+  - gem update --system
+  - gem install bundler
+  - sudo rm /etc/ImageMagick-6/policy.xml
 
 gemfile:
   - gemfiles/4.2.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,11 @@ script: "bundle exec rake clean spec cucumber"
 
 addons:
   apt:
+    update: true
     packages:
-    - imagemagick libmagickcore-dev libmagickwand-dev libjpeg
+    - libjpeg-dev
+    - libpng-dev
+    - libgif-dev
     - ghostscript
 
 gemfile:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-# sudo: false
 
 rvm:
   - 2.1
@@ -13,9 +12,6 @@ addons:
   apt:
     update: true
     packages:
-    - libjpeg-dev
-    - libpng-dev
-    - libgif-dev
     - ghostscript
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script: "bundle exec rake clean spec cucumber"
 addons:
   apt:
     packages:
-    - libjpeg
+    - imagemagick libmagickcore-dev libmagickwand-dev libjpeg
     - ghostscript
 
 gemfile:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ addons:
     - ghostscript
 
 before_install:
-  - gem update --system
-  - gem install bundler
   - sudo rm /etc/ImageMagick-6/policy.xml
 
 gemfile:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ script: "bundle exec rake clean spec cucumber"
 addons:
   apt:
     packages:
+    - libjpeg
     - ghostscript
 
 gemfile:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
     - libjpeg-dev
     - libpng-dev
     - libgif-dev
-    - ghostscript-9.20
+    - ghostscript
 
 before_install:
   - gem update --system

--- a/spec/paperclip/attachment_processing_spec.rb
+++ b/spec/paperclip/attachment_processing_spec.rb
@@ -9,7 +9,7 @@ describe 'Attachment Processing' do
       Dummy.validates_attachment_content_type :avatar, content_type: "image/png"
       instance = Dummy.new
       attachment = instance.avatar
-      attachment.expects(:post_process_styles)
+      expect(attachment).to receive(:post_process_styles)
 
       attachment.assign(file)
     end
@@ -19,7 +19,7 @@ describe 'Attachment Processing' do
       Dummy.validates_attachment_content_type :avatar, not: "image/png"
       instance = Dummy.new
       attachment = instance.avatar
-      attachment.expects(:post_process_styles).never
+      expect(attachment).not_to receive(:post_process_styles)
 
       attachment.assign(file)
     end
@@ -29,7 +29,7 @@ describe 'Attachment Processing' do
       Dummy.validates_attachment_content_type :avatar, content_type: "image/tiff"
       instance = Dummy.new
       attachment = instance.avatar
-      attachment.expects(:post_process_styles).never
+      expect(attachment).not_to receive(:post_process_styles)
 
       attachment.assign(file)
     end
@@ -39,7 +39,7 @@ describe 'Attachment Processing' do
       Dummy.validates_attachment_content_type :avatar, content_type: "image/tiff", if: lambda{false}
       instance = Dummy.new
       attachment = instance.avatar
-      attachment.expects(:post_process_styles)
+      expect(attachment).to receive(:post_process_styles)
 
       attachment.assign(invalid_assignment)
     end
@@ -51,7 +51,7 @@ describe 'Attachment Processing' do
       Dummy.validates_attachment :avatar, content_type: {content_type: "image/png"}
       instance = Dummy.new
       attachment = instance.avatar
-      attachment.expects(:post_process_styles)
+      expect(attachment).to receive(:post_process_styles)
 
       attachment.assign(file)
     end
@@ -61,7 +61,7 @@ describe 'Attachment Processing' do
       Dummy.validates_attachment :avatar, content_type: {not: "image/png"}
       instance = Dummy.new
       attachment = instance.avatar
-      attachment.expects(:post_process_styles).never
+      expect(attachment).not_to receive(:post_process_styles)
 
       attachment.assign(file)
     end
@@ -71,7 +71,7 @@ describe 'Attachment Processing' do
       Dummy.validates_attachment :avatar, content_type: {content_type: "image/tiff"}
       instance = Dummy.new
       attachment = instance.avatar
-      attachment.expects(:post_process_styles).never
+      expect(attachment).not_to receive(:post_process_styles)
 
       attachment.assign(file)
     end

--- a/spec/paperclip/attachment_spec.rb
+++ b/spec/paperclip/attachment_spec.rb
@@ -235,7 +235,7 @@ describe Paperclip::Attachment do
     dummy = Dummy.new
     dummy.id = 1234
     dummy.avatar_file_name = "fake.jpg"
-    dummy.stubs(:new_record?).returns(false)
+    allow(dummy).to receive(:new_record?).and_return(false)
     expected_string = '{"avatar":"/system/dummies/avatars/000/001/234/original/fake.jpg"}'
     # active_model pre-3.2 checks only by calling any? on it, thus it doesn't work if it is empty
     assert_equal expected_string, dummy.to_json(only: [:dummy_key_for_old_active_model], methods: [:avatar])
@@ -315,7 +315,8 @@ describe Paperclip::Attachment do
     before do
       rebuild_model path: ":id.omg/:id-bbq/:idwhat/:id_partition.wtf"
       @dummy = Dummy.new
-      @dummy.stubs(:id).returns(1024)
+
+      allow(@dummy).to receive(:id).and_return(1024)
       @file = File.new(fixture_file("5k.png"), 'rb')
       @dummy.avatar = @file
     end
@@ -331,9 +332,9 @@ describe Paperclip::Attachment do
     before do
       @file = StringIO.new("...")
       @zone = 'UTC'
-      Time.stubs(:zone).returns(@zone)
+      allow(Time).to receive(:zone).and_return(@zone)
       @zone_default = 'Eastern Time (US & Canada)'
-      Time.stubs(:zone_default).returns(@zone_default)
+      allow(Time).to receive(:zone_default).and_return(@zone_default)
     end
 
     context "using default time zone" do
@@ -409,10 +410,10 @@ describe Paperclip::Attachment do
       @id = 1024
       rebuild_model path: ":rails_env/:id.png"
       @dummy = Dummy.new
-      @dummy.stubs(:id).returns(@id)
+      allow(@dummy).to receive(:id).and_return(@id)
       @file = StringIO.new(".")
       @dummy.avatar = @file
-      Rails.stubs(:env).returns(@rails_env)
+      allow(Rails).to receive(:env).and_return(@rails_env)
     end
 
     it "returns the proper path" do
@@ -427,7 +428,7 @@ describe Paperclip::Attachment do
         default_style: :default
       @attachment = Dummy.new.avatar
       @file = File.open(fixture_file("5k.png"))
-      @file.stubs(:original_filename).returns("file.png")
+      allow(@file).to receive(:original_filename).and_return("file.png")
     end
     it "returns the right extension for the path" do
       @attachment.assign(@file)
@@ -493,8 +494,8 @@ describe Paperclip::Attachment do
     end
 
     it "only processes the provided style" do
-      @attachment.expects(:post_process).with(:thumb)
-      @attachment.expects(:post_process).with(:large).never
+      expect(@attachment).to receive(:post_process).with(:thumb)
+      expect(@attachment).to receive(:post_process).with(:large).never
       @attachment.assign(@file)
     end
   end
@@ -512,8 +513,8 @@ describe Paperclip::Attachment do
     end
 
     it "only processes the provided style" do
-      @attachment.expects(:post_process).with(:thumb)
-      @attachment.expects(:post_process).with(:large).never
+      expect(@attachment).to receive(:post_process).with(:thumb)
+      expect(@attachment).to receive(:post_process).with(:large).never
       @attachment.assign(@file)
       @attachment.save
     end
@@ -641,7 +642,7 @@ describe Paperclip::Attachment do
     before do
       class Paperclip::Test < Paperclip::Processor; end
       @file = StringIO.new("...")
-      Paperclip::Test.stubs(:make).returns(@file)
+      allow(Paperclip::Test).to receive(:make).and_return(@file)
 
       rebuild_model styles: { normal: '' }, processors: lambda { |a| [ :test ] }
       @attachment = Dummy.new.avatar
@@ -663,12 +664,12 @@ describe Paperclip::Attachment do
       rebuild_model processor: [:thumbnail], styles: { small: '' }, whiny_thumbnails: true
       @dummy = Dummy.new
       @file = StringIO.new("...")
-      @file.stubs(:to_tempfile).returns(@file)
+      allow(@file).to receive(:to_tempfile).and_return(@file)
     end
 
     context "when error is meaningful for the end user" do
       before do
-        Paperclip::Thumbnail.expects(:make).raises(
+        expect(Paperclip::Thumbnail).to receive(:make).and_raise(
           Paperclip::Errors::NotIdentifiedByImageMagickError,
           "cannot be processed."
         )
@@ -686,7 +687,7 @@ describe Paperclip::Attachment do
 
     context "when error is intended for the developer" do
       before do
-        Paperclip::Thumbnail.expects(:make).raises(
+        expect(Paperclip::Thumbnail).to receive(:make).and_raise(
           Paperclip::Errors::CommandNotFoundError
         )
       end
@@ -706,9 +707,9 @@ describe Paperclip::Attachment do
       rebuild_model processors: [:thumbnail, :test], styles: @style_params
       @dummy = Dummy.new
       @file = StringIO.new("...")
-      @file.stubs(:close)
-      Paperclip::Test.stubs(:make).returns(@file)
-      Paperclip::Thumbnail.stubs(:make).returns(@file)
+      allow(@file).to receive(:close)
+      allow(Paperclip::Test).to receive(:make).and_return(@file)
+      allow(Paperclip::Thumbnail).to receive(:make).and_return(@file)
     end
 
     context "when assigned" do
@@ -740,7 +741,7 @@ describe Paperclip::Attachment do
       end
 
       it "calls #make and unlinks intermediary files afterward" do
-        @dummy.avatar.expects(:unlink_files).with([@file, @file])
+        expect(@dummy.avatar).to receive(:unlink_files).with([@file, @file])
 
         @dummy.avatar = @file
       end
@@ -754,13 +755,13 @@ describe Paperclip::Attachment do
       end
       rebuild_model processors: [:test], styles: { once: "100x100" }
       @file = StringIO.new("...")
-      @file.stubs(:close)
+      allow(@file).to receive(:close)
       @dummy = Dummy.new
     end
 
     context "when assigned" do
       it "#calls #make and doesn't unlink the original file" do
-        @dummy.avatar.expects(:unlink_files).with([])
+        expect(@dummy.avatar).to receive(:unlink_files).with([])
 
         @dummy.avatar = @file
       end
@@ -835,45 +836,45 @@ describe Paperclip::Attachment do
         def do_after_all; end
       end
       @file  = StringIO.new(".")
-      @file.stubs(:to_tempfile).returns(@file)
+      allow(@file).to receive(:to_tempfile).and_return(@file)
       @dummy = Dummy.new
-      Paperclip::Thumbnail.stubs(:make).returns(@file)
+      allow(Paperclip::Thumbnail).to receive(:make).and_return(@file)
       @attachment = @dummy.avatar
     end
 
     it "calls the defined callbacks when assigned" do
-      @dummy.expects(:do_before_avatar).with()
-      @dummy.expects(:do_after_avatar).with()
-      @dummy.expects(:do_before_all).with()
-      @dummy.expects(:do_after_all).with()
-      Paperclip::Thumbnail.expects(:make).returns(@file)
+      expect(@dummy).to receive(:do_before_avatar)
+      expect(@dummy).to receive(:do_after_avatar)
+      expect(@dummy).to receive(:do_before_all)
+      expect(@dummy).to receive(:do_after_all)
+      expect(Paperclip::Thumbnail).to receive(:make).and_return(@file)
       @dummy.avatar = @file
     end
 
     it "does not cancel the processing if a before_post_process returns nil" do
-      @dummy.expects(:do_before_avatar).with().returns(nil)
-      @dummy.expects(:do_after_avatar).with()
-      @dummy.expects(:do_before_all).with().returns(nil)
-      @dummy.expects(:do_after_all).with()
-      Paperclip::Thumbnail.expects(:make).returns(@file)
+      expect(@dummy).to receive(:do_before_avatar).and_return(nil)
+      expect(@dummy).to receive(:do_after_avatar)
+      expect(@dummy).to receive(:do_before_all).and_return(nil)
+      expect(@dummy).to receive(:do_after_all)
+      expect(Paperclip::Thumbnail).to receive(:make).and_return(@file)
       @dummy.avatar = @file
     end
 
     it "cancels the processing if a before_post_process returns false" do
-      @dummy.expects(:do_before_avatar).never
-      @dummy.expects(:do_after_avatar).never
-      @dummy.expects(:do_before_all).with().returns(false)
-      @dummy.expects(:do_after_all)
-      Paperclip::Thumbnail.expects(:make).never
+      expect(@dummy).to receive(:do_before_avatar).never
+      expect(@dummy).to receive(:do_after_avatar).never
+      expect(@dummy).to receive(:do_before_all).and_return(false)
+      expect(@dummy).to receive(:do_after_all)
+      expect(Paperclip::Thumbnail).not_to receive(:make)
       @dummy.avatar = @file
     end
 
     it "cancels the processing if a before_avatar_post_process returns false" do
-      @dummy.expects(:do_before_avatar).with().returns(false)
-      @dummy.expects(:do_after_avatar)
-      @dummy.expects(:do_before_all).with().returns(true)
-      @dummy.expects(:do_after_all)
-      Paperclip::Thumbnail.expects(:make).never
+      expect(@dummy).to receive(:do_before_avatar).and_return(false)
+      expect(@dummy).to receive(:do_after_avatar)
+      expect(@dummy).to receive(:do_before_all).and_return(true)
+      expect(@dummy).to receive(:do_after_all)
+      expect(Paperclip::Thumbnail).not_to receive(:make)
       @dummy.avatar = @file
     end
   end
@@ -912,7 +913,7 @@ describe Paperclip::Attachment do
     before do
       rebuild_model
       @file = File.new(fixture_file("5k.png"), "rb")
-      @file.stubs(:original_filename).returns("sheep_say_bæ.png")
+      allow(@file).to receive(:original_filename).and_return("sheep_say_bæ.png")
       @dummy = Dummy.new
       @dummy.avatar = @file
     end
@@ -938,7 +939,7 @@ describe Paperclip::Attachment do
 
           context "at beginning of filename" do
             before do
-              @file.stubs(:original_filename).returns("#{character}filename.png")
+              allow(@file).to receive(:original_filename).and_return("#{character}filename.png")
               @dummy = Dummy.new
               @dummy.avatar = @file
             end
@@ -950,7 +951,7 @@ describe Paperclip::Attachment do
 
           context "at end of filename" do
             before do
-              @file.stubs(:original_filename).returns("filename.png#{character}")
+              allow(@file).to receive(:original_filename).and_return("filename.png#{character}")
               @dummy = Dummy.new
               @dummy.avatar = @file
             end
@@ -962,7 +963,7 @@ describe Paperclip::Attachment do
 
           context "in the middle of filename" do
             before do
-              @file.stubs(:original_filename).returns("file#{character}name.png")
+              allow(@file).to receive(:original_filename).and_return("file#{character}name.png")
               @dummy = Dummy.new
               @dummy.avatar = @file
             end
@@ -989,7 +990,7 @@ describe Paperclip::Attachment do
         before do
           Paperclip::Attachment.default_options.merge! restricted_characters: /o/
 
-          @file.stubs(:original_filename).returns("goood.png")
+          allow(@file).to receive(:original_filename).and_return("goood.png")
           @dummy = Dummy.new
           @dummy.avatar = @file
         end
@@ -1003,7 +1004,7 @@ describe Paperclip::Attachment do
         before do
           Paperclip::Attachment.default_options.merge! restricted_characters: nil
 
-          @file.stubs(:original_filename).returns("goood.png")
+          allow(@file).to receive(:original_filename).and_return("goood.png")
           @dummy = Dummy.new
           @dummy.avatar = @file
         end
@@ -1028,7 +1029,7 @@ describe Paperclip::Attachment do
           "from_proc_#{str}"
         end
 
-        @file.stubs(:original_filename).returns("goood.png")
+        allow(@file).to receive(:original_filename).and_return("goood.png")
         @dummy = Dummy.new
         @dummy.avatar = @file
         assert_equal "from_proc_goood.png", @dummy.avatar.original_filename
@@ -1042,7 +1043,7 @@ describe Paperclip::Attachment do
         end
         Paperclip::Attachment.default_options[:filename_cleaner] = MyCleaner.new
 
-        @file.stubs(:original_filename).returns("goood.png")
+        allow(@file).to receive(:original_filename).and_return("goood.png")
         @dummy = Dummy.new
         @dummy.avatar = @file
         assert_equal "foo", @dummy.avatar.original_filename
@@ -1062,13 +1063,13 @@ describe Paperclip::Attachment do
                              small: ["32x32#", :jpg]},
                     default_style: :small
       @instance = Dummy.new
-      @instance.stubs(:id).returns 123
+      allow(@instance).to receive(:id).and_return 123
       @file = File.new(fixture_file("uppercase.PNG"), 'rb')
 
       @attachment = @instance.avatar
 
       now = Time.now
-      Time.stubs(:now).returns(now)
+      allow(Time).to receive(:now).and_return(now)
       @attachment.assign(@file)
       @attachment.save
     end
@@ -1097,7 +1098,7 @@ describe Paperclip::Attachment do
       FileUtils.rm_rf("tmp")
       rebuild_model
       @instance = Dummy.new
-      @instance.stubs(:id).returns 123
+      allow(@instance).to receive(:id).and_return 123
       # @attachment = Paperclip::Attachment.new(:avatar, @instance)
       @attachment = @instance.avatar
       @file = File.new(fixture_file("5k.png"), 'rb')
@@ -1145,13 +1146,13 @@ describe Paperclip::Attachment do
 
     context "with a file assigned in the database" do
       before do
-        @attachment.stubs(:instance_read).with(:file_name).returns("5k.png")
-        @attachment.stubs(:instance_read).with(:content_type).returns("image/png")
-        @attachment.stubs(:instance_read).with(:file_size).returns(12345)
+        allow(@attachment).to receive(:instance_read).with(:file_name).and_return("5k.png")
+        allow(@attachment).to receive(:instance_read).with(:content_type).and_return("image/png")
+        allow(@attachment).to receive(:instance_read).with(:file_size).and_return(12345)
         dtnow = DateTime.now
         @now = Time.now
-        Time.stubs(:now).returns(@now)
-        @attachment.stubs(:instance_read).with(:updated_at).returns(dtnow)
+        allow(Time).to receive(:now).and_return(@now)
+        allow(@attachment).to receive(:instance_read).with(:updated_at).and_return(dtnow)
       end
 
       it "returns the proper path when filename has a single .'s" do
@@ -1159,7 +1160,7 @@ describe Paperclip::Attachment do
       end
 
       it "returns the proper path when filename has multiple .'s" do
-        @attachment.stubs(:instance_read).with(:file_name).returns("5k.old.png")
+        allow(@attachment).to receive(:instance_read).with(:file_name).and_return("5k.old.png")
         assert_equal File.expand_path("tmp/avatars/dummies/original/#{@instance.id}/5k.old.png"), File.expand_path(@attachment.path)
       end
 
@@ -1171,7 +1172,7 @@ describe Paperclip::Attachment do
             small: ["32x32#", :jpg]
           }
           @instance = Dummy.new
-          @instance.stubs(:id).returns 123
+          allow(@instance).to receive(:id).and_return 123
           @file = File.new(fixture_file("5k.png"), 'rb')
           @attachment = @instance.avatar
         end
@@ -1179,7 +1180,7 @@ describe Paperclip::Attachment do
         context "and assigned a file" do
           before do
             now = Time.now
-            Time.stubs(:now).returns(now)
+            allow(Time).to receive(:now).and_return(now)
             @attachment.assign(@file)
           end
 
@@ -1219,33 +1220,33 @@ describe Paperclip::Attachment do
               end
 
               it "deletes the files after assigning nil" do
-                @attachment.expects(:instance_write).with(:file_name, nil)
-                @attachment.expects(:instance_write).with(:content_type, nil)
-                @attachment.expects(:instance_write).with(:file_size, nil)
-                @attachment.expects(:instance_write).with(:fingerprint, nil)
-                @attachment.expects(:instance_write).with(:updated_at, nil)
+                expect(@attachment).to receive(:instance_write).with(:file_name, nil)
+                expect(@attachment).to receive(:instance_write).with(:content_type, nil)
+                expect(@attachment).to receive(:instance_write).with(:file_size, nil)
+                expect(@attachment).to receive(:instance_write).with(:fingerprint, nil)
+                expect(@attachment).to receive(:instance_write).with(:updated_at, nil)
                 @attachment.assign nil
                 @attachment.save
                 @existing_names.each{|f| assert_file_not_exists(f) }
               end
 
               it "deletes the files when you call #clear and #save" do
-                @attachment.expects(:instance_write).with(:file_name, nil)
-                @attachment.expects(:instance_write).with(:content_type, nil)
-                @attachment.expects(:instance_write).with(:file_size, nil)
-                @attachment.expects(:instance_write).with(:fingerprint, nil)
-                @attachment.expects(:instance_write).with(:updated_at, nil)
+                expect(@attachment).to receive(:instance_write).with(:file_name, nil)
+                expect(@attachment).to receive(:instance_write).with(:content_type, nil)
+                expect(@attachment).to receive(:instance_write).with(:file_size, nil)
+                expect(@attachment).to receive(:instance_write).with(:fingerprint, nil)
+                expect(@attachment).to receive(:instance_write).with(:updated_at, nil)
                 @attachment.clear
                 @attachment.save
                 @existing_names.each{|f| assert_file_not_exists(f) }
               end
 
               it "deletes the files when you call #delete" do
-                @attachment.expects(:instance_write).with(:file_name, nil)
-                @attachment.expects(:instance_write).with(:content_type, nil)
-                @attachment.expects(:instance_write).with(:file_size, nil)
-                @attachment.expects(:instance_write).with(:fingerprint, nil)
-                @attachment.expects(:instance_write).with(:updated_at, nil)
+                expect(@attachment).to receive(:instance_write).with(:file_name, nil)
+                expect(@attachment).to receive(:instance_write).with(:content_type, nil)
+                expect(@attachment).to receive(:instance_write).with(:file_size, nil)
+                expect(@attachment).to receive(:instance_write).with(:fingerprint, nil)
+                expect(@attachment).to receive(:instance_write).with(:updated_at, nil)
                 @attachment.destroy
                 @existing_names.each{|f| assert_file_not_exists(f) }
               end
@@ -1256,33 +1257,33 @@ describe Paperclip::Attachment do
                 end
 
                 it "keeps the files after assigning nil" do
-                  @attachment.expects(:instance_write).with(:file_name, nil)
-                  @attachment.expects(:instance_write).with(:content_type, nil)
-                  @attachment.expects(:instance_write).with(:file_size, nil)
-                  @attachment.expects(:instance_write).with(:fingerprint, nil)
-                  @attachment.expects(:instance_write).with(:updated_at, nil)
+                  expect(@attachment).to receive(:instance_write).with(:file_name, nil)
+                  expect(@attachment).to receive(:instance_write).with(:content_type, nil)
+                  expect(@attachment).to receive(:instance_write).with(:file_size, nil)
+                  expect(@attachment).to receive(:instance_write).with(:fingerprint, nil)
+                  expect(@attachment).to receive(:instance_write).with(:updated_at, nil)
                   @attachment.assign nil
                   @attachment.save
                   @existing_names.each{|f| assert_file_exists(f) }
                 end
 
                 it "keeps the files when you call #clear and #save" do
-                  @attachment.expects(:instance_write).with(:file_name, nil)
-                  @attachment.expects(:instance_write).with(:content_type, nil)
-                  @attachment.expects(:instance_write).with(:file_size, nil)
-                  @attachment.expects(:instance_write).with(:fingerprint, nil)
-                  @attachment.expects(:instance_write).with(:updated_at, nil)
+                  expect(@attachment).to receive(:instance_write).with(:file_name, nil)
+                  expect(@attachment).to receive(:instance_write).with(:content_type, nil)
+                  expect(@attachment).to receive(:instance_write).with(:file_size, nil)
+                  expect(@attachment).to receive(:instance_write).with(:fingerprint, nil)
+                  expect(@attachment).to receive(:instance_write).with(:updated_at, nil)
                   @attachment.clear
                   @attachment.save
                   @existing_names.each{|f| assert_file_exists(f) }
                 end
 
                 it "keeps the files when you call #delete" do
-                  @attachment.expects(:instance_write).with(:file_name, nil)
-                  @attachment.expects(:instance_write).with(:content_type, nil)
-                  @attachment.expects(:instance_write).with(:file_size, nil)
-                  @attachment.expects(:instance_write).with(:fingerprint, nil)
-                  @attachment.expects(:instance_write).with(:updated_at, nil)
+                  expect(@attachment).to receive(:instance_write).with(:file_name, nil)
+                  expect(@attachment).to receive(:instance_write).with(:content_type, nil)
+                  expect(@attachment).to receive(:instance_write).with(:file_size, nil)
+                  expect(@attachment).to receive(:instance_write).with(:fingerprint, nil)
+                  expect(@attachment).to receive(:instance_write).with(:updated_at, nil)
                   @attachment.destroy
                   @existing_names.each{|f| assert_file_exists(f) }
                 end
@@ -1343,7 +1344,7 @@ describe Paperclip::Attachment do
 
       it "returns the creation time when sent #avatar_created_at" do
         now = Time.now
-        Time.stubs(:now).returns(now)
+        allow(Time).to receive(:now).and_return(now)
         @dummy.avatar = @file
         assert_equal now.to_i, @dummy.avatar.created_at
       end
@@ -1351,9 +1352,9 @@ describe Paperclip::Attachment do
       it "returns the creation time when sent #avatar_created_at and the entry has been updated" do
         creation = 2.hours.ago
         now = Time.now
-        Time.stubs(:now).returns(creation)
+        allow(Time).to receive(:now).and_return(creation)
         @dummy.avatar = @file
-        Time.stubs(:now).returns(now)
+        allow(Time).to receive(:now).and_return(now)
         @dummy.avatar = @file
         assert_equal creation.to_i, @dummy.avatar.created_at
         assert_not_equal now.to_i, @dummy.avatar.created_at
@@ -1380,16 +1381,16 @@ describe Paperclip::Attachment do
 
       it "returns the right value when sent #avatar_updated_at" do
         now = Time.now
-        Time.stubs(:now).returns(now)
+        allow(Time).to receive(:now).and_return(now)
         @dummy.avatar = @file
         assert_equal now.to_i, @dummy.avatar.updated_at
       end
     end
 
     it "does not calculate fingerprint" do
-      Digest::MD5.stubs(:file)
+      allow(Digest::MD5).to receive(:file)
       @dummy.avatar = @file
-      expect(Digest::MD5).to have_received(:file).never
+      expect(Digest::MD5).not_to have_received(:file)
     end
 
     it "does not assign fingerprint" do
@@ -1537,7 +1538,7 @@ describe Paperclip::Attachment do
     after { @file.close }
 
     it "is not deleted when the model fails to destroy" do
-      @dummy.stubs(:destroy).raises(Exception)
+      allow(@dummy).to receive(:destroy).and_raise(Exception)
 
       assert_raises Exception do
         @dummy.destroy

--- a/spec/paperclip/file_command_content_type_detector_spec.rb
+++ b/spec/paperclip/file_command_content_type_detector_spec.rb
@@ -12,14 +12,14 @@ describe Paperclip::FileCommandContentTypeDetector do
   end
 
   it 'returns a sensible default when the file command is missing' do
-    Paperclip.stubs(:run).raises(Terrapin::CommandLineError.new)
+    allow(Paperclip).to receive(:run).and_raise(Terrapin::CommandLineError.new)
     @filename = "/path/to/something"
     assert_equal "application/octet-stream",
       Paperclip::FileCommandContentTypeDetector.new(@filename).detect
   end
 
   it 'returns a sensible default on the odd chance that run returns nil' do
-    Paperclip.stubs(:run).returns(nil)
+    allow(Paperclip).to receive(:run).and_return(nil)
     assert_equal "application/octet-stream",
       Paperclip::FileCommandContentTypeDetector.new("windows").detect
   end
@@ -28,12 +28,12 @@ describe Paperclip::FileCommandContentTypeDetector do
     let(:detector) { Paperclip::FileCommandContentTypeDetector.new("html") }
 
     it "does work with the output of old versions of file" do
-      Paperclip.stubs(:run).returns("text/html charset=us-ascii")
+      allow(Paperclip).to receive(:run).and_return("text/html charset=us-ascii")
       expect(detector.detect).to eq("text/html")
     end
 
     it "does work with the output of new versions of file" do
-      Paperclip.stubs(:run).returns("text/html; charset=us-ascii")
+      allow(Paperclip).to receive(:run).and_return("text/html; charset=us-ascii")
       expect(detector.detect).to eq("text/html")
     end
   end

--- a/spec/paperclip/geometry_detector_spec.rb
+++ b/spec/paperclip/geometry_detector_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Paperclip::GeometryDetector do
   it 'identifies an image and extract its dimensions' do
-    Paperclip::GeometryParser.stubs(:new).with("434x66,").returns(stub(make: :correct))
+    allow_any_instance_of(Paperclip::GeometryParser).to receive(:make).and_return(:correct)
     file = fixture_file("5k.png")
     factory = Paperclip::GeometryDetector.new(file)
 
@@ -12,7 +12,7 @@ describe Paperclip::GeometryDetector do
   end
 
   it 'identifies an image and extract its dimensions and orientation' do
-    Paperclip::GeometryParser.stubs(:new).with("300x200,6").returns(stub(make: :correct))
+    allow_any_instance_of(Paperclip::GeometryParser).to receive(:make).and_return(:correct)
     file = fixture_file("rotated.jpg")
     factory = Paperclip::GeometryDetector.new(file)
 
@@ -24,7 +24,7 @@ describe Paperclip::GeometryDetector do
   it 'avoids reading EXIF orientation if so configured' do
     begin
       Paperclip.options[:use_exif_orientation] = false
-      Paperclip::GeometryParser.stubs(:new).with("300x200,1").returns(stub(make: :correct))
+      allow_any_instance_of(Paperclip::GeometryParser).to receive(:make).and_return(:correct)
       file = fixture_file("rotated.jpg")
       factory = Paperclip::GeometryDetector.new(file)
 

--- a/spec/paperclip/geometry_parser_spec.rb
+++ b/spec/paperclip/geometry_parser_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 describe Paperclip::GeometryParser do
   it 'identifies an image and extract its dimensions with no orientation' do
-    Paperclip::Geometry.stubs(:new).with(
+    allow(Paperclip::Geometry).to receive(:new).with(
       height: '73',
       width: '434',
       modifier: nil,
       orientation: nil
-    ).returns(:correct)
+    ).and_return(:correct)
     factory = Paperclip::GeometryParser.new("434x73")
 
     output = factory.make
@@ -16,12 +16,12 @@ describe Paperclip::GeometryParser do
   end
 
   it 'identifies an image and extract its dimensions with an empty orientation' do
-    Paperclip::Geometry.stubs(:new).with(
+    allow(Paperclip::Geometry).to receive(:new).with(
       height: '73',
       width: '434',
       modifier: nil,
       orientation: ''
-    ).returns(:correct)
+    ).and_return(:correct)
     factory = Paperclip::GeometryParser.new("434x73,")
 
     output = factory.make
@@ -30,12 +30,12 @@ describe Paperclip::GeometryParser do
   end
 
   it 'identifies an image and extract its dimensions and orientation' do
-    Paperclip::Geometry.stubs(:new).with(
+    allow(Paperclip::Geometry).to receive(:new).with(
       height: '200',
       width: '300',
       modifier: nil,
       orientation: '6'
-    ).returns(:correct)
+    ).and_return(:correct)
     factory = Paperclip::GeometryParser.new("300x200,6")
 
     output = factory.make
@@ -44,12 +44,12 @@ describe Paperclip::GeometryParser do
   end
 
   it 'identifies an image and extract its dimensions and modifier' do
-    Paperclip::Geometry.stubs(:new).with(
+    allow(Paperclip::Geometry).to receive(:new).with(
       height: '64',
       width: '64',
       modifier: '#',
       orientation: nil
-    ).returns(:correct)
+    ).and_return(:correct)
     factory = Paperclip::GeometryParser.new("64x64#")
 
     output = factory.make
@@ -58,12 +58,12 @@ describe Paperclip::GeometryParser do
   end
 
   it 'identifies an image and extract its dimensions, orientation, and modifier' do
-    Paperclip::Geometry.stubs(:new).with(
+    allow(Paperclip::Geometry).to receive(:new).with(
       height: '50',
       width: '100',
       modifier: '>',
       orientation: '7'
-    ).returns(:correct)
+    ).and_return(:correct)
     factory = Paperclip::GeometryParser.new("100x50,7>")
 
     output = factory.make

--- a/spec/paperclip/geometry_spec.rb
+++ b/spec/paperclip/geometry_spec.rb
@@ -162,7 +162,7 @@ describe Paperclip::Geometry do
 
     it "does not generate from a file with no path" do
       file = mock("file", path: "")
-      file.stubs(:respond_to?).with(:path).returns(true)
+      allow(file).to receive(:respond_to?).with(:path).and_return(true)
       expect { @geo = Paperclip::Geometry.from_file(file) }.to raise_error(Paperclip::Errors::NotIdentifiedByImageMagickError)
     end
 

--- a/spec/paperclip/geometry_spec.rb
+++ b/spec/paperclip/geometry_spec.rb
@@ -161,7 +161,7 @@ describe Paperclip::Geometry do
     end
 
     it "does not generate from a file with no path" do
-      file = spy("file", path: "")
+      file = double("file", path: "")
       allow(file).to receive(:respond_to?).with(:path).and_return(true)
       expect { @geo = Paperclip::Geometry.from_file(file) }.to raise_error(Paperclip::Errors::NotIdentifiedByImageMagickError)
     end

--- a/spec/paperclip/geometry_spec.rb
+++ b/spec/paperclip/geometry_spec.rb
@@ -161,7 +161,7 @@ describe Paperclip::Geometry do
     end
 
     it "does not generate from a file with no path" do
-      file = mock("file", path: "")
+      file = spy("file", path: "")
       allow(file).to receive(:respond_to?).with(:path).and_return(true)
       expect { @geo = Paperclip::Geometry.from_file(file) }.to raise_error(Paperclip::Errors::NotIdentifiedByImageMagickError)
     end

--- a/spec/paperclip/has_attached_file_spec.rb
+++ b/spec/paperclip/has_attached_file_spec.rb
@@ -75,7 +75,7 @@ describe Paperclip::HasAttachedFile do
       @stubbed_class = stub_class
       if options.present?
         options[:unstub_methods].each do |method|
-          @stubbed_class.unstub(method)
+          allow(@stubbed_class).to receive(method).and_call_original
         end
       end
     end
@@ -90,7 +90,7 @@ describe Paperclip::HasAttachedFile do
 
     def defines_class_method(method_name)
       a_class = @stubbed_class
-      a_class.class.stubs(:define_method)
+      allow(a_class.class).to receive(:define_method)
 
       Paperclip::HasAttachedFile.define_on(a_class, @attachment_name, {})
 
@@ -107,7 +107,7 @@ describe Paperclip::HasAttachedFile do
 
     def registers_attachment
       a_class = @stubbed_class
-      Paperclip::AttachmentRegistry.stubs(:register)
+      allow(Paperclip::AttachmentRegistry).to receive(:register)
 
       Paperclip::HasAttachedFile.define_on(a_class, @attachment_name, {size: 1})
 

--- a/spec/paperclip/has_attached_file_spec.rb
+++ b/spec/paperclip/has_attached_file_spec.rb
@@ -67,7 +67,7 @@ describe Paperclip::HasAttachedFile do
   end
 
   class AttachmentAdder
-    include Mocha::API
+    # include Mocha::API
     include RSpec::Matchers
 
     def initialize(attachment_name, options = {})

--- a/spec/paperclip/has_attached_file_spec.rb
+++ b/spec/paperclip/has_attached_file_spec.rb
@@ -1,158 +1,79 @@
 require 'spec_helper'
 
 describe Paperclip::HasAttachedFile do
+  let(:a_class) { spy("Class") }
+
   context '#define_on' do
     it 'defines a setter on the class object' do
-      assert_adding_attachment('avatar').defines_method('avatar=')
+      Paperclip::HasAttachedFile.define_on(a_class, 'avatar', {})
+      expect(a_class).to have_received(:define_method).with('avatar=')
     end
 
     it 'defines a getter on the class object' do
-      assert_adding_attachment('avatar').defines_method('avatar')
+      Paperclip::HasAttachedFile.define_on(a_class, 'avatar', {})
+      expect(a_class).to have_received(:define_method).with('avatar')
     end
 
     it 'defines a query on the class object' do
-      assert_adding_attachment('avatar').defines_method('avatar?')
+      Paperclip::HasAttachedFile.define_on(a_class, 'avatar', {})
+      expect(a_class).to have_received(:define_method).with('avatar?')
     end
 
     it 'defines a method on the class to get all of its attachments' do
-      assert_adding_attachment('avatar').defines_class_method('attachment_definitions')
+      allow(a_class).to receive(:extend)
+      Paperclip::HasAttachedFile.define_on(a_class, 'avatar', {})
+      expect(a_class).to have_received(:extend).with(Paperclip::HasAttachedFile::ClassMethods)
     end
 
     it 'flushes errors as part of validations' do
-      assert_adding_attachment('avatar').defines_validation
+      Paperclip::HasAttachedFile.define_on(a_class, 'avatar', {})
+      expect(a_class).to have_received(:validates_each).with('avatar')
     end
 
     it 'registers the attachment with Paperclip::AttachmentRegistry' do
-      assert_adding_attachment('avatar').registers_attachment
+      allow(Paperclip::AttachmentRegistry).to receive(:register)
+      Paperclip::HasAttachedFile.define_on(a_class, 'avatar', size: 1)
+      expect(Paperclip::AttachmentRegistry).to have_received(:register).with(a_class, 'avatar', size: 1)
     end
 
     it 'defines an after_save callback' do
-      assert_adding_attachment('avatar').defines_callback('after_save')
+      Paperclip::HasAttachedFile.define_on(a_class, 'avatar', {})
+      expect(a_class).to have_received('after_save')
     end
 
     it 'defines a before_destroy callback' do
-      assert_adding_attachment('avatar').defines_callback('before_destroy')
+      Paperclip::HasAttachedFile.define_on(a_class, 'avatar', {})
+      expect(a_class).to have_received('before_destroy')
     end
 
     it 'defines an after_commit callback' do
-      assert_adding_attachment('avatar').defines_callback('after_commit')
+      Paperclip::HasAttachedFile.define_on(a_class, 'avatar', {})
+      expect(a_class).to have_received('after_commit')
     end
 
     context 'when the class does not allow after_commit callbacks' do
       it 'defines an after_destroy callback' do
-        assert_adding_attachment(
-          'avatar',
-          unstub_methods: [:after_commit]
-        ).defines_callback('after_destroy')
+        a_class = double('class', after_destroy: nil, validates_each: nil, define_method: nil, after_save: nil, before_destroy: nil, define_paperclip_callbacks: nil, validates_media_type_spoof_detection: nil)
+        Paperclip::HasAttachedFile.define_on(a_class, 'avatar', {})
+        expect(a_class).to have_received('after_destroy')
       end
     end
 
     it 'defines the Paperclip-specific callbacks' do
-      assert_adding_attachment('avatar').defines_callback('define_paperclip_callbacks')
+      Paperclip::HasAttachedFile.define_on(a_class, 'avatar', validate_media_type: false)
+      expect(a_class).to_not have_received(:validates_media_type_spoof_detection)
+      expect(a_class).to have_received('define_paperclip_callbacks')
+
     end
 
     it 'does not define a media_type check if told not to' do
-      assert_adding_attachment('avatar').does_not_set_up_media_type_check_validation
-    end
-
-    it 'does define a media_type check if told to' do
-      assert_adding_attachment('avatar').sets_up_media_type_check_validation
-    end
-  end
-
-  private
-
-  def assert_adding_attachment(attachment_name, options={})
-    AttachmentAdder.new(attachment_name, options)
-  end
-
-  class AttachmentAdder
-    # include Mocha::API
-    include RSpec::Matchers
-
-    def initialize(attachment_name, options = {})
-      @attachment_name = attachment_name
-      @stubbed_class = stub_class
-      if options.present?
-        options[:unstub_methods].each do |method|
-          allow(@stubbed_class).to receive(method).and_call_original
-        end
-      end
-    end
-
-    def defines_method(method_name)
-      a_class = @stubbed_class
-
-      Paperclip::HasAttachedFile.define_on(a_class, @attachment_name, {})
-
-      expect(a_class).to have_received(:define_method).with(method_name)
-    end
-
-    def defines_class_method(method_name)
-      a_class = @stubbed_class
-      allow(a_class.class).to receive(:define_method)
-
-      Paperclip::HasAttachedFile.define_on(a_class, @attachment_name, {})
-
-      expect(a_class).to have_received(:extend).with(Paperclip::HasAttachedFile::ClassMethods)
-    end
-
-    def defines_validation
-      a_class = @stubbed_class
-
-      Paperclip::HasAttachedFile.define_on(a_class, @attachment_name, {})
-
-      expect(a_class).to have_received(:validates_each).with(@attachment_name)
-    end
-
-    def registers_attachment
-      a_class = @stubbed_class
-      allow(Paperclip::AttachmentRegistry).to receive(:register)
-
-      Paperclip::HasAttachedFile.define_on(a_class, @attachment_name, {size: 1})
-
-      expect(Paperclip::AttachmentRegistry).to have_received(:register).with(a_class, @attachment_name, {size: 1})
-    end
-
-    def defines_callback(callback_name)
-      a_class = @stubbed_class
-
-      Paperclip::HasAttachedFile.define_on(a_class, @attachment_name, {})
-
-      expect(a_class).to have_received(callback_name.to_sym)
-    end
-
-    def does_not_set_up_media_type_check_validation
-      a_class = stub_class
-
-      Paperclip::HasAttachedFile.define_on(a_class, @attachment_name, { validate_media_type: false })
-
+      Paperclip::HasAttachedFile.define_on(a_class, 'avatar', validate_media_type: false)
       expect(a_class).to_not have_received(:validates_media_type_spoof_detection)
     end
 
-    def sets_up_media_type_check_validation
-      a_class = stub_class
-
-      Paperclip::HasAttachedFile.define_on(a_class, @attachment_name, { validate_media_type: true })
-
+    it 'does define a media_type check if told to' do
+      Paperclip::HasAttachedFile.define_on(a_class, 'avatar', validate_media_type: true)
       expect(a_class).to have_received(:validates_media_type_spoof_detection)
-    end
-
-    private
-
-    def stub_class
-      stub('class',
-           validates_each: nil,
-           define_method: nil,
-           after_save: nil,
-           before_destroy: nil,
-           after_commit: nil,
-           after_destroy: nil,
-           define_paperclip_callbacks: nil,
-           extend: nil,
-           name: 'Billy',
-           validates_media_type_spoof_detection: nil
-          )
     end
   end
 end

--- a/spec/paperclip/has_attached_file_spec.rb
+++ b/spec/paperclip/has_attached_file_spec.rb
@@ -127,7 +127,7 @@ describe Paperclip::HasAttachedFile do
 
       Paperclip::HasAttachedFile.define_on(a_class, @attachment_name, { validate_media_type: false })
 
-      expect(a_class).to have_received(:validates_media_type_spoof_detection).never
+      expect(a_class).to_not have_received(:validates_media_type_spoof_detection)
     end
 
     def sets_up_media_type_check_validation

--- a/spec/paperclip/integration_spec.rb
+++ b/spec/paperclip/integration_spec.rb
@@ -153,9 +153,9 @@ describe 'Paperclip' do
 
     it "allows us to selectively create each thumbnail" do
       skip <<-EXPLANATION
-	#reprocess! calls #assign which calls Paperclip.io_adapters.for 
+	#reprocess! calls #assign which calls Paperclip.io_adapters.for
 	which creates the tempfile. #assign then calls #post_process_file which
-	calls MediaTypeSpoofDetectionValidator#validate_each which calls 
+	calls MediaTypeSpoofDetectionValidator#validate_each which calls
 	Paperclip.io_adapters.for, which creates another tempfile. That first
 	tempfile is the one that leaks.
       EXPLANATION
@@ -231,7 +231,7 @@ describe 'Paperclip' do
 
       context 'and deleted where the delete fails' do
         it "does not die if an unexpected SystemCallError happens" do
-          FileUtils.stubs(:rmdir).raises(Errno::EPIPE)
+          allow(FileUtils).to receive(:rmdir).and_raise(Errno::EPIPE)
           assert_nothing_raised do
             @dummy.avatar.clear
             @dummy.save
@@ -284,7 +284,7 @@ describe 'Paperclip' do
   end
 
   it "skips chmod operation, when override_file_permissions is set to false (e.g. useful when using CIFS mounts)" do
-    FileUtils.expects(:chmod).never
+    expect(FileUtils).to_not receive(:chmod)
 
     rebuild_model override_file_permissions: false
     dummy = Dummy.create!
@@ -471,7 +471,7 @@ describe 'Paperclip' do
       before do
         @dummy.avatar.options[:styles][:mini] = "25x25#"
         @dummy.avatar.instance_variable_set :@normalized_styles, nil
-        Time.stubs(now: Time.now + 10)
+        allow(Time).to receive(:now).and_return(Time.now + 10)
         @dummy.avatar.reprocess!
         @dummy.reload
       end
@@ -657,7 +657,7 @@ describe 'Paperclip' do
 
       context "with non-english character in the file name" do
         before do
-          @file.stubs(:original_filename).returns("クリップ.png")
+          allow(@file).to receive(:original_filename).and_return("クリップ.png")
           @dummy.avatar = @file
         end
 

--- a/spec/paperclip/interpolations_spec.rb
+++ b/spec/paperclip/interpolations_spec.rb
@@ -25,27 +25,27 @@ describe Paperclip::Interpolations do
 
   it "returns the class of the instance" do
     class Thing ; end
-    attachment = mock
+    attachment = spy
     expect(attachment).to receive(:instance).and_return(attachment)
     expect(attachment).to receive(:class).and_return(Thing)
     assert_equal "things", Paperclip::Interpolations.class(attachment, :style)
   end
 
   it "returns the basename of the file" do
-    attachment = mock
-    expect(attachment).to receive(:original_filename).and_return("one.jpg").times(1)
+    attachment = spy
+    expect(attachment).to receive(:original_filename).and_return("one.jpg")
     assert_equal "one", Paperclip::Interpolations.basename(attachment, :style)
   end
 
   it "returns the extension of the file" do
-    attachment = mock
+    attachment = spy
     expect(attachment).to receive(:original_filename).and_return("one.jpg")
     expect(attachment).to receive(:styles).and_return({})
     assert_equal "jpg", Paperclip::Interpolations.extension(attachment, :style)
   end
 
   it "returns the extension of the file as the format if defined in the style" do
-    attachment = mock
+    attachment = spy
     expect(attachment).to_not receive(:original_filename)
     expect(attachment).to receive(:styles).at_least(2).times.and_return({style: {format: "png"}})
 
@@ -55,7 +55,7 @@ describe Paperclip::Interpolations do
   end
 
   it "returns the extension of the file based on the content type" do
-    attachment = mock
+    attachment = spy
     expect(attachment).to receive(:content_type).and_return('image/png')
     expect(attachment).to receive(:styles).and_return({})
     interpolations = Paperclip::Interpolations
@@ -64,7 +64,7 @@ describe Paperclip::Interpolations do
   end
 
   it "returns the original extension of the file if it matches a content type extension" do
-    attachment = mock
+    attachment = spy
     expect(attachment).to receive(:content_type).and_return('image/jpeg')
     expect(attachment).to receive(:styles).and_return({})
     interpolations = Paperclip::Interpolations
@@ -73,21 +73,21 @@ describe Paperclip::Interpolations do
   end
 
   it "returns the extension of the file with a dot" do
-    attachment = mock
+    attachment = spy
     expect(attachment).to receive(:original_filename).and_return("one.jpg")
     expect(attachment).to receive(:styles).and_return({})
     assert_equal ".jpg", Paperclip::Interpolations.dotextension(attachment, :style)
   end
 
   it "returns the extension of the file without a dot if the extension is empty" do
-    attachment = mock
+    attachment = spy
     expect(attachment).to receive(:original_filename).and_return("one")
     expect(attachment).to receive(:styles).and_return({})
     assert_equal "", Paperclip::Interpolations.dotextension(attachment, :style)
   end
 
   it "returns the latter half of the content type of the extension if no match found" do
-    attachment = mock
+    attachment = spy
     allow(attachment).to receive(:content_type).at_least(1).times.and_return('not/found')
     allow(attachment).to receive(:styles).and_return({})
     interpolations = Paperclip::Interpolations
@@ -96,7 +96,7 @@ describe Paperclip::Interpolations do
   end
 
   it "returns the format if defined in the style, ignoring the content type" do
-    attachment = mock
+    attachment = spy
     expect(attachment).to receive(:content_type).and_return('image/jpeg')
     expect(attachment).to receive(:styles).and_return({style: {format: "png"}})
     interpolations = Paperclip::Interpolations
@@ -105,42 +105,42 @@ describe Paperclip::Interpolations do
   end
 
   it "is able to handle numeric style names" do
-    attachment = mock(
+    attachment = spy(
       styles: {:"4" => {format: :expected_extension}}
     )
     assert_equal :expected_extension, Paperclip::Interpolations.extension(attachment, 4)
   end
 
   it "returns the #to_param of the attachment" do
-    attachment = mock
+    attachment = spy
     expect(attachment).to receive(:to_param).and_return("23-awesome")
     expect(attachment).to receive(:instance).and_return(attachment)
     assert_equal "23-awesome", Paperclip::Interpolations.param(attachment, :style)
   end
 
   it "returns the id of the attachment" do
-    attachment = mock
+    attachment = spy
     expect(attachment).to receive(:id).and_return(23)
     expect(attachment).to receive(:instance).and_return(attachment)
     assert_equal 23, Paperclip::Interpolations.id(attachment, :style)
   end
 
   it "returns nil for attachments to new records" do
-    attachment = mock
+    attachment = spy
     expect(attachment).to receive(:id).and_return(nil)
     expect(attachment).to receive(:instance).and_return(attachment)
     assert_nil Paperclip::Interpolations.id(attachment, :style)
   end
 
   it "returns the partitioned id of the attachment when the id is an integer" do
-    attachment = mock
+    attachment = spy
     expect(attachment).to receive(:id).and_return(23)
     expect(attachment).to receive(:instance).and_return(attachment)
     assert_equal "000/000/023", Paperclip::Interpolations.id_partition(attachment, :style)
   end
 
   it "returns the partitioned id when the id is above 999_999_999" do
-    attachment = mock
+    attachment = spy
     expect(attachment).to receive(:id).and_return(Paperclip::Interpolations::ID_PARTITION_LIMIT)
     expect(attachment).to receive(:instance).and_return(attachment)
     assert_equal "001/000/000/000",
@@ -148,21 +148,21 @@ describe Paperclip::Interpolations do
   end
 
   it "returns the partitioned id of the attachment when the id is a string" do
-    attachment = mock
+    attachment = spy
     expect(attachment).to receive(:id).and_return("32fnj23oio2f")
     expect(attachment).to receive(:instance).and_return(attachment)
     assert_equal "32f/nj2/3oi", Paperclip::Interpolations.id_partition(attachment, :style)
   end
 
   it "returns nil for the partitioned id of an attachment to a new record (when the id is nil)" do
-    attachment = mock
+    attachment = spy
     expect(attachment).to receive(:id).and_return(nil)
     expect(attachment).to receive(:instance).and_return(attachment)
     assert_nil Paperclip::Interpolations.id_partition(attachment, :style)
   end
 
   it "returns the name of the attachment" do
-    attachment = mock
+    attachment = spy
     expect(attachment).to receive(:name).and_return("file")
     assert_equal "files", Paperclip::Interpolations.attachment(attachment, :style)
   end
@@ -172,13 +172,13 @@ describe Paperclip::Interpolations do
   end
 
   it "returns the default style" do
-    attachment = mock
+    attachment = spy
     expect(attachment).to receive(:default_style).and_return(:default_style)
     assert_equal :default_style, Paperclip::Interpolations.style(attachment, nil)
   end
 
   it "reinterpolates :url" do
-    attachment = mock
+    attachment = spy
     expect(attachment).to receive(:url).with(:style, timestamp: false, escape: false).and_return("1234")
     assert_equal "1234", Paperclip::Interpolations.url(attachment, :style)
   end
@@ -194,28 +194,28 @@ describe Paperclip::Interpolations do
   end
 
   it "returns the filename as basename.extension" do
-    attachment = mock
+    attachment = spy
     expect(attachment).to receive(:styles).and_return({})
-    expect(attachment).to receive(:original_filename).and_return("one.jpg").times(2)
+    expect(attachment).to receive(:original_filename).and_return("one.jpg").twice
     assert_equal "one.jpg", Paperclip::Interpolations.filename(attachment, :style)
   end
 
   it "returns the filename as basename.extension when format supplied" do
-    attachment = mock
+    attachment = spy
     expect(attachment).to receive(:styles).and_return({style: {format: :png}})
-    expect(attachment).to receive(:original_filename).and_return("one.jpg").times(1)
+    expect(attachment).to receive(:original_filename).and_return("one.jpg").once
     assert_equal "one.png", Paperclip::Interpolations.filename(attachment, :style)
   end
 
   it "returns the filename as basename when extension is blank" do
-    attachment = mock
+    attachment = spy
     allow(attachment).to receive(:styles).and_return({})
     allow(attachment).to receive(:original_filename).and_return("one")
     assert_equal "one", Paperclip::Interpolations.filename(attachment, :style)
   end
 
   it "returns the basename when the extension contains regexp special characters" do
-    attachment = mock
+    attachment = spy
     allow(attachment).to receive(:styles).and_return({})
     allow(attachment).to receive(:original_filename).and_return("one.ab)")
     assert_equal "one", Paperclip::Interpolations.basename(attachment, :style)
@@ -224,30 +224,30 @@ describe Paperclip::Interpolations do
   it "returns the timestamp" do
     now = Time.now
     zone = 'UTC'
-    attachment = mock
+    attachment = spy
     expect(attachment).to receive(:instance_read).with(:updated_at).and_return(now)
     expect(attachment).to receive(:time_zone).and_return(zone)
     assert_equal now.in_time_zone(zone).to_s, Paperclip::Interpolations.timestamp(attachment, :style)
   end
 
   it "returns updated_at" do
-    attachment = mock
+    attachment = spy
     seconds_since_epoch = 1234567890
     expect(attachment).to receive(:updated_at).and_return(seconds_since_epoch)
     assert_equal seconds_since_epoch, Paperclip::Interpolations.updated_at(attachment, :style)
   end
 
   it "returns attachment's hash when passing both arguments" do
-    attachment = mock
+    attachment = spy
     fake_hash = "a_wicked_secure_hash"
     expect(attachment).to receive(:hash_key).and_return(fake_hash)
     assert_equal fake_hash, Paperclip::Interpolations.hash(attachment, :style)
   end
 
   it "returns Object#hash when passing no argument" do
-    attachment = mock
+    attachment = spy
     fake_hash = "a_wicked_secure_hash"
-    expect(attachment).to_not receive(:hash_key).and_return(fake_hash)
+    expect(attachment).to_not receive(:hash_key)
     assert_not_equal fake_hash, Paperclip::Interpolations.hash
   end
 

--- a/spec/paperclip/interpolations_spec.rb
+++ b/spec/paperclip/interpolations_spec.rb
@@ -26,28 +26,28 @@ describe Paperclip::Interpolations do
   it "returns the class of the instance" do
     class Thing ; end
     attachment = mock
-    attachment.expects(:instance).returns(attachment)
-    attachment.expects(:class).returns(Thing)
+    expect(attachment).to receive(:instance).and_return(attachment)
+    expect(attachment).to receive(:class).and_return(Thing)
     assert_equal "things", Paperclip::Interpolations.class(attachment, :style)
   end
 
   it "returns the basename of the file" do
     attachment = mock
-    attachment.expects(:original_filename).returns("one.jpg").times(1)
+    expect(attachment).to receive(:original_filename).and_return("one.jpg").times(1)
     assert_equal "one", Paperclip::Interpolations.basename(attachment, :style)
   end
 
   it "returns the extension of the file" do
     attachment = mock
-    attachment.expects(:original_filename).returns("one.jpg")
-    attachment.expects(:styles).returns({})
+    expect(attachment).to receive(:original_filename).and_return("one.jpg")
+    expect(attachment).to receive(:styles).and_return({})
     assert_equal "jpg", Paperclip::Interpolations.extension(attachment, :style)
   end
 
   it "returns the extension of the file as the format if defined in the style" do
     attachment = mock
-    attachment.expects(:original_filename).never
-    attachment.expects(:styles).twice.returns({style: {format: "png"}})
+    expect(attachment).to_not receive(:original_filename)
+    expect(attachment).to receive(:styles).at_least(2).times.and_return({style: {format: "png"}})
 
     [:style, 'style'].each do |style|
       assert_equal "png", Paperclip::Interpolations.extension(attachment, style)
@@ -56,51 +56,51 @@ describe Paperclip::Interpolations do
 
   it "returns the extension of the file based on the content type" do
     attachment = mock
-    attachment.expects(:content_type).returns('image/png')
-    attachment.expects(:styles).returns({})
+    expect(attachment).to receive(:content_type).and_return('image/png')
+    expect(attachment).to receive(:styles).and_return({})
     interpolations = Paperclip::Interpolations
-    interpolations.expects(:extension).returns('random')
+    expect(interpolations).to receive(:extension).and_return('random')
     assert_equal "png", interpolations.content_type_extension(attachment, :style)
   end
 
   it "returns the original extension of the file if it matches a content type extension" do
     attachment = mock
-    attachment.expects(:content_type).returns('image/jpeg')
-    attachment.expects(:styles).returns({})
+    expect(attachment).to receive(:content_type).and_return('image/jpeg')
+    expect(attachment).to receive(:styles).and_return({})
     interpolations = Paperclip::Interpolations
-    interpolations.expects(:extension).returns('jpe')
+    expect(interpolations).to receive(:extension).and_return('jpe')
     assert_equal "jpe", interpolations.content_type_extension(attachment, :style)
   end
 
   it "returns the extension of the file with a dot" do
     attachment = mock
-    attachment.expects(:original_filename).returns("one.jpg")
-    attachment.expects(:styles).returns({})
+    expect(attachment).to receive(:original_filename).and_return("one.jpg")
+    expect(attachment).to receive(:styles).and_return({})
     assert_equal ".jpg", Paperclip::Interpolations.dotextension(attachment, :style)
   end
 
   it "returns the extension of the file without a dot if the extension is empty" do
     attachment = mock
-    attachment.expects(:original_filename).returns("one")
-    attachment.expects(:styles).returns({})
+    expect(attachment).to receive(:original_filename).and_return("one")
+    expect(attachment).to receive(:styles).and_return({})
     assert_equal "", Paperclip::Interpolations.dotextension(attachment, :style)
   end
 
   it "returns the latter half of the content type of the extension if no match found" do
     attachment = mock
-    attachment.expects(:content_type).at_least_once().returns('not/found')
-    attachment.expects(:styles).returns({})
+    allow(attachment).to receive(:content_type).at_least(1).times.and_return('not/found')
+    allow(attachment).to receive(:styles).and_return({})
     interpolations = Paperclip::Interpolations
-    interpolations.expects(:extension).returns('random')
+    expect(interpolations).to receive(:extension).and_return('random')
     assert_equal "found", interpolations.content_type_extension(attachment, :style)
   end
 
   it "returns the format if defined in the style, ignoring the content type" do
     attachment = mock
-    attachment.expects(:content_type).returns('image/jpeg')
-    attachment.expects(:styles).returns({style: {format: "png"}})
+    expect(attachment).to receive(:content_type).and_return('image/jpeg')
+    expect(attachment).to receive(:styles).and_return({style: {format: "png"}})
     interpolations = Paperclip::Interpolations
-    interpolations.expects(:extension).returns('random')
+    expect(interpolations).to receive(:extension).and_return('random')
     assert_equal "png", interpolations.content_type_extension(attachment, :style)
   end
 
@@ -113,58 +113,57 @@ describe Paperclip::Interpolations do
 
   it "returns the #to_param of the attachment" do
     attachment = mock
-    attachment.expects(:to_param).returns("23-awesome")
-    attachment.expects(:instance).returns(attachment)
+    expect(attachment).to receive(:to_param).and_return("23-awesome")
+    expect(attachment).to receive(:instance).and_return(attachment)
     assert_equal "23-awesome", Paperclip::Interpolations.param(attachment, :style)
   end
 
   it "returns the id of the attachment" do
     attachment = mock
-    attachment.expects(:id).returns(23)
-    attachment.expects(:instance).returns(attachment)
+    expect(attachment).to receive(:id).and_return(23)
+    expect(attachment).to receive(:instance).and_return(attachment)
     assert_equal 23, Paperclip::Interpolations.id(attachment, :style)
   end
 
   it "returns nil for attachments to new records" do
     attachment = mock
-    attachment.expects(:id).returns(nil)
-    attachment.expects(:instance).returns(attachment)
+    expect(attachment).to receive(:id).and_return(nil)
+    expect(attachment).to receive(:instance).and_return(attachment)
     assert_nil Paperclip::Interpolations.id(attachment, :style)
   end
 
   it "returns the partitioned id of the attachment when the id is an integer" do
     attachment = mock
-    attachment.expects(:id).returns(23)
-    attachment.expects(:instance).returns(attachment)
+    expect(attachment).to receive(:id).and_return(23)
+    expect(attachment).to receive(:instance).and_return(attachment)
     assert_equal "000/000/023", Paperclip::Interpolations.id_partition(attachment, :style)
   end
 
   it "returns the partitioned id when the id is above 999_999_999" do
     attachment = mock
-    attachment.expects(:id).
-      returns(Paperclip::Interpolations::ID_PARTITION_LIMIT)
-    attachment.expects(:instance).returns(attachment)
+    expect(attachment).to receive(:id).and_return(Paperclip::Interpolations::ID_PARTITION_LIMIT)
+    expect(attachment).to receive(:instance).and_return(attachment)
     assert_equal "001/000/000/000",
       Paperclip::Interpolations.id_partition(attachment, :style)
   end
 
   it "returns the partitioned id of the attachment when the id is a string" do
     attachment = mock
-    attachment.expects(:id).returns("32fnj23oio2f")
-    attachment.expects(:instance).returns(attachment)
+    expect(attachment).to receive(:id).and_return("32fnj23oio2f")
+    expect(attachment).to receive(:instance).and_return(attachment)
     assert_equal "32f/nj2/3oi", Paperclip::Interpolations.id_partition(attachment, :style)
   end
 
   it "returns nil for the partitioned id of an attachment to a new record (when the id is nil)" do
     attachment = mock
-    attachment.expects(:id).returns(nil)
-    attachment.expects(:instance).returns(attachment)
+    expect(attachment).to receive(:id).and_return(nil)
+    expect(attachment).to receive(:instance).and_return(attachment)
     assert_nil Paperclip::Interpolations.id_partition(attachment, :style)
   end
 
   it "returns the name of the attachment" do
     attachment = mock
-    attachment.expects(:name).returns("file")
+    expect(attachment).to receive(:name).and_return("file")
     assert_equal "files", Paperclip::Interpolations.attachment(attachment, :style)
   end
 
@@ -174,13 +173,13 @@ describe Paperclip::Interpolations do
 
   it "returns the default style" do
     attachment = mock
-    attachment.expects(:default_style).returns(:default_style)
+    expect(attachment).to receive(:default_style).and_return(:default_style)
     assert_equal :default_style, Paperclip::Interpolations.style(attachment, nil)
   end
 
   it "reinterpolates :url" do
     attachment = mock
-    attachment.expects(:url).with(:style, timestamp: false, escape: false).returns("1234")
+    expect(attachment).to receive(:url).with(:style, timestamp: false, escape: false).and_return("1234")
     assert_equal "1234", Paperclip::Interpolations.url(attachment, :style)
   end
 
@@ -196,29 +195,29 @@ describe Paperclip::Interpolations do
 
   it "returns the filename as basename.extension" do
     attachment = mock
-    attachment.expects(:styles).returns({})
-    attachment.expects(:original_filename).returns("one.jpg").times(2)
+    expect(attachment).to receive(:styles).and_return({})
+    expect(attachment).to receive(:original_filename).and_return("one.jpg").times(2)
     assert_equal "one.jpg", Paperclip::Interpolations.filename(attachment, :style)
   end
 
   it "returns the filename as basename.extension when format supplied" do
     attachment = mock
-    attachment.expects(:styles).returns({style: {format: :png}})
-    attachment.expects(:original_filename).returns("one.jpg").times(1)
+    expect(attachment).to receive(:styles).and_return({style: {format: :png}})
+    expect(attachment).to receive(:original_filename).and_return("one.jpg").times(1)
     assert_equal "one.png", Paperclip::Interpolations.filename(attachment, :style)
   end
 
   it "returns the filename as basename when extension is blank" do
     attachment = mock
-    attachment.stubs(:styles).returns({})
-    attachment.stubs(:original_filename).returns("one")
+    allow(attachment).to receive(:styles).and_return({})
+    allow(attachment).to receive(:original_filename).and_return("one")
     assert_equal "one", Paperclip::Interpolations.filename(attachment, :style)
   end
-  
+
   it "returns the basename when the extension contains regexp special characters" do
     attachment = mock
-    attachment.stubs(:styles).returns({})
-    attachment.stubs(:original_filename).returns("one.ab)")
+    allow(attachment).to receive(:styles).and_return({})
+    allow(attachment).to receive(:original_filename).and_return("one.ab)")
     assert_equal "one", Paperclip::Interpolations.basename(attachment, :style)
   end
 
@@ -226,36 +225,36 @@ describe Paperclip::Interpolations do
     now = Time.now
     zone = 'UTC'
     attachment = mock
-    attachment.expects(:instance_read).with(:updated_at).returns(now)
-    attachment.expects(:time_zone).returns(zone)
+    expect(attachment).to receive(:instance_read).with(:updated_at).and_return(now)
+    expect(attachment).to receive(:time_zone).and_return(zone)
     assert_equal now.in_time_zone(zone).to_s, Paperclip::Interpolations.timestamp(attachment, :style)
   end
 
   it "returns updated_at" do
     attachment = mock
     seconds_since_epoch = 1234567890
-    attachment.expects(:updated_at).returns(seconds_since_epoch)
+    expect(attachment).to receive(:updated_at).and_return(seconds_since_epoch)
     assert_equal seconds_since_epoch, Paperclip::Interpolations.updated_at(attachment, :style)
   end
 
   it "returns attachment's hash when passing both arguments" do
     attachment = mock
     fake_hash = "a_wicked_secure_hash"
-    attachment.expects(:hash_key).returns(fake_hash)
+    expect(attachment).to receive(:hash_key).and_return(fake_hash)
     assert_equal fake_hash, Paperclip::Interpolations.hash(attachment, :style)
   end
 
   it "returns Object#hash when passing no argument" do
     attachment = mock
     fake_hash = "a_wicked_secure_hash"
-    attachment.expects(:hash_key).never.returns(fake_hash)
+    expect(attachment).to_not receive(:hash_key).and_return(fake_hash)
     assert_not_equal fake_hash, Paperclip::Interpolations.hash
   end
 
   it "calls all expected interpolations with the given arguments" do
-    Paperclip::Interpolations.expects(:id).with(:attachment, :style).returns(1234)
-    Paperclip::Interpolations.expects(:attachment).with(:attachment, :style).returns("attachments")
-    Paperclip::Interpolations.expects(:notreal).never
+    expect(Paperclip::Interpolations).to receive(:id).with(:attachment, :style).and_return(1234)
+    expect(Paperclip::Interpolations).to receive(:attachment).with(:attachment, :style).and_return("attachments")
+    expect(Paperclip::Interpolations).to_not receive(:notreal)
     value = Paperclip::Interpolations.interpolate(":notreal/:id/:attachment", :attachment, :style)
     assert_equal ":notreal/1234/attachments", value
   end
@@ -264,7 +263,7 @@ describe Paperclip::Interpolations do
     Paperclip.interpolates :foo? do
       "bar"
     end
-    Paperclip::Interpolations.expects(:fool).never
+    expect(Paperclip::Interpolations).to_not receive(:fool)
     value = Paperclip::Interpolations.interpolate(":fo/:foo?")
     assert_equal ":fo/bar", value
   end

--- a/spec/paperclip/io_adapters/abstract_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/abstract_adapter_spec.rb
@@ -15,7 +15,7 @@ describe Paperclip::AbstractAdapter do
     before do
       allow(subject).to receive(:path).and_return("image.png")
       allow(Paperclip).to receive(:run).and_return("image/png\n")
-      allow(Paperclip::ContentTypeDetector.any_instance).to receive(:type_from_mime_magic).and_return("image/png")
+      allow_any_instance_of(Paperclip::ContentTypeDetector).to receive(:type_from_mime_magic).and_return("image/png")
     end
 
     it "returns the content type without newline" do
@@ -31,14 +31,14 @@ describe Paperclip::AbstractAdapter do
 
   context "delegation" do
     before do
-      subject.tempfile = stub("Tempfile")
+      subject.tempfile = spy("Tempfile")
     end
 
     [:binmode, :binmode?, :close, :close!, :closed?, :eof?, :path, :readbyte, :rewind, :unlink].each do |method|
       it "delegates #{method} to @tempfile" do
         allow(subject.tempfile).to receive(method)
         subject.public_send(method)
-        assert_received subject.tempfile, method
+        expect(subject.tempfile).to have_received(method)
       end
     end
   end

--- a/spec/paperclip/io_adapters/abstract_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/abstract_adapter_spec.rb
@@ -13,9 +13,9 @@ describe Paperclip::AbstractAdapter do
 
   context "content type from file contents" do
     before do
-      subject.stubs(:path).returns("image.png")
-      Paperclip.stubs(:run).returns("image/png\n")
-      Paperclip::ContentTypeDetector.any_instance.stubs(:type_from_mime_magic).returns("image/png")
+      allow(subject).to receive(:path).and_return("image.png")
+      allow(Paperclip).to receive(:run).and_return("image/png\n")
+      allow(Paperclip::ContentTypeDetector.any_instance).to receive(:type_from_mime_magic).and_return("image/png")
     end
 
     it "returns the content type without newline" do
@@ -36,7 +36,7 @@ describe Paperclip::AbstractAdapter do
 
     [:binmode, :binmode?, :close, :close!, :closed?, :eof?, :path, :readbyte, :rewind, :unlink].each do |method|
       it "delegates #{method} to @tempfile" do
-        subject.tempfile.stubs(method)
+        allow(subject.tempfile).to receive(method)
         subject.public_send(method)
         assert_received subject.tempfile, method
       end
@@ -70,7 +70,7 @@ describe Paperclip::AbstractAdapter do
     subject { TestAdapter.new(nil, options) }
 
     before do
-      subject.stubs(:path).returns(fixture_file("50x50.png"))
+      allow(subject).to receive(:path).and_return(fixture_file("50x50.png"))
     end
 
     context "MD5" do
@@ -152,7 +152,7 @@ describe Paperclip::AbstractAdapter do
     end
 
     it "should be able to reopen the file after symlink has failed" do
-      FileUtils.expects(:ln).raises(Errno::EXDEV)
+      expect(FileUtils).to receive(:ln).and_raise(Errno::EXDEV)
 
       expect(subject.copy_to_tempfile(file).read).to eq(body)
     end

--- a/spec/paperclip/io_adapters/abstract_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/abstract_adapter_spec.rb
@@ -31,7 +31,7 @@ describe Paperclip::AbstractAdapter do
 
   context "delegation" do
     before do
-      subject.tempfile = spy("Tempfile")
+      subject.tempfile = double("Tempfile")
     end
 
     [:binmode, :binmode?, :close, :close!, :closed?, :eof?, :path, :readbyte, :rewind, :unlink].each do |method|

--- a/spec/paperclip/io_adapters/attachment_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/attachment_adapter_spec.rb
@@ -61,7 +61,7 @@ describe Paperclip::AttachmentAdapter do
     before do
       file_contents = IO.read(fixture_file("animated.gif"))
       @file = StringIO.new(file_contents)
-      @file.stubs(:original_filename).returns('image:restricted.gif')
+      allow(@file).to receive(:original_filename).and_return('image:restricted.gif')
       @file.binmode
 
       @attachment.assign(@file)

--- a/spec/paperclip/io_adapters/file_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/file_adapter_spec.rb
@@ -77,7 +77,7 @@ describe Paperclip::FileAdapter do
         before do
           allow(MIME::Types).to receive(:type_for).and_return([])
           allow(Paperclip).to receive(:run).and_return("application/vnd.ms-office\n")
-          allow(Paperclip::ContentTypeDetector.any_instance)
+          allow_any_instance_of(Paperclip::ContentTypeDetector)
             .to receive(:type_from_mime_magic).and_return("application/vnd.ms-office")
 
           @subject = Paperclip.io_adapters.for(@file)

--- a/spec/paperclip/io_adapters/file_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/file_adapter_spec.rb
@@ -60,7 +60,7 @@ describe Paperclip::FileAdapter do
 
       context "file with multiple possible content type" do
         before do
-          MIME::Types.stubs(:type_for).returns([MIME::Type.new('image/x-png'), MIME::Type.new('image/png')])
+          allow(MIME::Types).to receive(:type_for).and_return([MIME::Type.new('image/x-png'), MIME::Type.new('image/png')])
           @subject = Paperclip.io_adapters.for(@file, hash_digest: Digest::MD5)
         end
 
@@ -75,10 +75,10 @@ describe Paperclip::FileAdapter do
 
       context "file with content type derived from file contents on *nix" do
         before do
-          MIME::Types.stubs(:type_for).returns([])
-          Paperclip.stubs(:run).returns("application/vnd.ms-office\n")
-          Paperclip::ContentTypeDetector.any_instance
-            .stubs(:type_from_mime_magic).returns("application/vnd.ms-office")
+          allow(MIME::Types).to receive(:type_for).and_return([])
+          allow(Paperclip).to receive(:run).and_return("application/vnd.ms-office\n")
+          allow(Paperclip::ContentTypeDetector.any_instance)
+            .to receive(:type_from_mime_magic).and_return("application/vnd.ms-office")
 
           @subject = Paperclip.io_adapters.for(@file)
         end
@@ -94,7 +94,7 @@ describe Paperclip::FileAdapter do
         @file = File.open(fixture_file("animated.gif")) do |file|
           StringIO.new(file.read)
         end
-        @file.stubs(:original_filename).returns('image:restricted.gif')
+        allow(@file).to receive(:original_filename).and_return('image:restricted.gif')
         @subject = Paperclip.io_adapters.for(@file)
       end
 

--- a/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
@@ -4,7 +4,7 @@ describe Paperclip::HttpUrlProxyAdapter do
   before do
     @open_return = StringIO.new("xxx")
     allow(@open_return).to receive(:meta).and_return("content-type" => "image/png")
-    allow(Paperclip::HttpUrlProxyAdapter.any_instance).to receive(:download_content).
+    allow_any_instance_of(Paperclip::HttpUrlProxyAdapter).to receive(:download_content).
       and_return(@open_return)
     Paperclip::HttpUrlProxyAdapter.register
   end
@@ -108,7 +108,7 @@ describe Paperclip::HttpUrlProxyAdapter do
 
   context "a url with special characters in the filename" do
     before do
-      allow(Paperclip::HttpUrlProxyAdapter.any_instance).to receive(:download_content).and_return(@open_return)
+      allow_any_instance_of(Paperclip::HttpUrlProxyAdapter).to receive(:download_content).and_return(@open_return)
     end
 
     let(:filename) do

--- a/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/http_url_proxy_adapter_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Paperclip::HttpUrlProxyAdapter do
   before do
     @open_return = StringIO.new("xxx")
-    @open_return.stubs(:meta).returns("content-type" => "image/png")
-    Paperclip::HttpUrlProxyAdapter.any_instance.stubs(:download_content).
-      returns(@open_return)
+    allow(@open_return).to receive(:meta).and_return("content-type" => "image/png")
+    allow(Paperclip::HttpUrlProxyAdapter.any_instance).to receive(:download_content).
+      and_return(@open_return)
     Paperclip::HttpUrlProxyAdapter.register
   end
 
@@ -108,8 +108,7 @@ describe Paperclip::HttpUrlProxyAdapter do
 
   context "a url with special characters in the filename" do
     before do
-      Paperclip::HttpUrlProxyAdapter.any_instance.stubs(:download_content).
-        returns(@open_return)
+      allow(Paperclip::HttpUrlProxyAdapter.any_instance).to receive(:download_content).and_return(@open_return)
     end
 
     let(:filename) do

--- a/spec/paperclip/io_adapters/uri_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/uri_adapter_spec.rb
@@ -6,8 +6,8 @@ describe Paperclip::UriAdapter do
 
   before do
     @open_return = StringIO.new("xxx")
-    @open_return.stubs(:content_type).returns(content_type)
-    @open_return.stubs(:meta).returns(meta)
+    allow(@open_return).to receive(:content_type).and_return(content_type)
+    allow(@open_return).to receive(:meta).and_return(meta)
     Paperclip::UriAdapter.register
   end
 
@@ -19,8 +19,8 @@ describe Paperclip::UriAdapter do
     let(:meta) { { "content-type" => "image/png" } }
 
     before do
-      Paperclip::UriAdapter.any_instance.
-        stubs(:download_content).returns(@open_return)
+      allow(Paperclip::UriAdapter.any_instance).
+        to receive(:download_content).and_return(@open_return)
 
       @uri = URI.parse("http://thoughtbot.com/images/thoughtbot-logo.png")
       @subject = Paperclip.io_adapters.for(@uri, hash_digest: Digest::MD5)
@@ -76,8 +76,8 @@ describe Paperclip::UriAdapter do
     let(:meta) { { "content-type" => "text/html" } }
 
     before do
-      Paperclip::UriAdapter.any_instance.
-        stubs(:download_content).returns(@open_return)
+      allow(Paperclip::UriAdapter.any_instance).
+        to receive(:download_content).and_return(@open_return)
 
       @uri = URI.parse("http://thoughtbot.com")
       @subject = Paperclip.io_adapters.for(@uri)
@@ -94,8 +94,8 @@ describe Paperclip::UriAdapter do
 
   context "a url with query params" do
     before do
-      Paperclip::UriAdapter.any_instance.
-        stubs(:download_content).returns(@open_return)
+      allow(Paperclip::UriAdapter.any_instance).
+        to receive(:download_content).and_return(@open_return)
 
       @uri = URI.parse("https://github.com/thoughtbot/paperclip?file=test")
       @subject = Paperclip.io_adapters.for(@uri)
@@ -111,8 +111,8 @@ describe Paperclip::UriAdapter do
     let(:filename_from_path) { "paperclip" }
 
     before do
-      Paperclip::UriAdapter.any_instance.
-        stubs(:download_content).returns(@open_return)
+      allow(Paperclip::UriAdapter.any_instance).
+        to receive(:download_content).and_return(@open_return)
 
       @uri = URI.parse(
         "https://github.com/thoughtbot/#{filename_from_path}?file=test")
@@ -174,8 +174,8 @@ describe Paperclip::UriAdapter do
 
   context "a url with restricted characters in the filename" do
     before do
-      Paperclip::UriAdapter.any_instance.
-        stubs(:download_content).returns(@open_return)
+      allow(Paperclip::UriAdapter.any_instance).
+        to receive(:download_content).and_return(@open_return)
 
       @uri = URI.parse("https://github.com/thoughtbot/paper:clip.jpg")
       @subject = Paperclip.io_adapters.for(@uri)
@@ -192,7 +192,7 @@ describe Paperclip::UriAdapter do
 
   describe "#download_content" do
     before do
-      Paperclip::UriAdapter.any_instance.stubs(:open).returns(@open_return)
+      allow(Paperclip::UriAdapter.any_instance).to receive(:open).and_return(@open_return)
       @uri = URI.parse("https://github.com/thoughtbot/paper:clip.jpg")
       @subject = Paperclip.io_adapters.for(@uri)
     end

--- a/spec/paperclip/io_adapters/uri_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/uri_adapter_spec.rb
@@ -19,7 +19,7 @@ describe Paperclip::UriAdapter do
     let(:meta) { { "content-type" => "image/png" } }
 
     before do
-      allow(Paperclip::UriAdapter.any_instance).
+      allow_any_instance_of(Paperclip::UriAdapter).
         to receive(:download_content).and_return(@open_return)
 
       @uri = URI.parse("http://thoughtbot.com/images/thoughtbot-logo.png")
@@ -76,7 +76,7 @@ describe Paperclip::UriAdapter do
     let(:meta) { { "content-type" => "text/html" } }
 
     before do
-      allow(Paperclip::UriAdapter.any_instance).
+      allow_any_instance_of(Paperclip::UriAdapter).
         to receive(:download_content).and_return(@open_return)
 
       @uri = URI.parse("http://thoughtbot.com")
@@ -94,7 +94,7 @@ describe Paperclip::UriAdapter do
 
   context "a url with query params" do
     before do
-      allow(Paperclip::UriAdapter.any_instance).
+      allow_any_instance_of(Paperclip::UriAdapter).
         to receive(:download_content).and_return(@open_return)
 
       @uri = URI.parse("https://github.com/thoughtbot/paperclip?file=test")
@@ -111,7 +111,7 @@ describe Paperclip::UriAdapter do
     let(:filename_from_path) { "paperclip" }
 
     before do
-      allow(Paperclip::UriAdapter.any_instance).
+      allow_any_instance_of(Paperclip::UriAdapter).
         to receive(:download_content).and_return(@open_return)
 
       @uri = URI.parse(
@@ -174,7 +174,7 @@ describe Paperclip::UriAdapter do
 
   context "a url with restricted characters in the filename" do
     before do
-      allow(Paperclip::UriAdapter.any_instance).
+      allow_any_instance_of(Paperclip::UriAdapter).
         to receive(:download_content).and_return(@open_return)
 
       @uri = URI.parse("https://github.com/thoughtbot/paper:clip.jpg")
@@ -192,7 +192,7 @@ describe Paperclip::UriAdapter do
 
   describe "#download_content" do
     before do
-      allow(Paperclip::UriAdapter.any_instance).to receive(:open).and_return(@open_return)
+      allow_any_instance_of(Paperclip::UriAdapter).to receive(:open).and_return(@open_return)
       @uri = URI.parse("https://github.com/thoughtbot/paper:clip.jpg")
       @subject = Paperclip.io_adapters.for(@uri)
     end
@@ -203,7 +203,7 @@ describe Paperclip::UriAdapter do
 
     context "with default read_timeout" do
       it "calls open without options" do
-        @subject.expects(:open).with(@uri, {}).at_least_once
+        expect(@subject).to receive(:open).with(@uri, {}).at_least(1).times
       end
     end
 
@@ -213,7 +213,7 @@ describe Paperclip::UriAdapter do
       end
 
       it "calls open with read_timeout option" do
-        @subject.expects(:open).with(@uri, read_timeout: 120).at_least_once
+        expect(@subject).to receive(:open).with(@uri, read_timeout: 120).at_least(1).times
       end
     end
   end

--- a/spec/paperclip/matchers/validate_attachment_size_matcher_spec.rb
+++ b/spec/paperclip/matchers/validate_attachment_size_matcher_spec.rb
@@ -75,7 +75,7 @@ describe Paperclip::Shoulda::Matchers::ValidateAttachmentSizeMatcher do
 
     it "be skipped" do
       dummy = Dummy.new
-      dummy.avatar.expects(:post_process).never
+      expect(dummy.avatar).to_not receive(:post_process)
       expect(matcher.greater_than(1024)).to accept(dummy)
     end
   end

--- a/spec/paperclip/media_type_spoof_detector_spec.rb
+++ b/spec/paperclip/media_type_spoof_detector_spec.rb
@@ -108,12 +108,12 @@ describe Paperclip::MediaTypeSpoofDetector do
     let(:detector) { Paperclip::MediaTypeSpoofDetector.new(file, "html", "") }
 
     it "does work with the output of old versions of file" do
-      Paperclip.stubs(:run).returns("text/html charset=us-ascii")
+      allow(Paperclip).to reject(:run).and_return("text/html charset=us-ascii")
       expect(detector.send(:type_from_file_command)).to eq("text/html")
     end
 
     it "does work with the output of new versions of file" do
-      Paperclip.stubs(:run).returns("text/html; charset=us-ascii")
+      allow(Paperclip).to reject(:run).and_return("text/html; charset=us-ascii")
       expect(detector.send(:type_from_file_command)).to eq("text/html")
     end
   end

--- a/spec/paperclip/media_type_spoof_detector_spec.rb
+++ b/spec/paperclip/media_type_spoof_detector_spec.rb
@@ -53,7 +53,7 @@ describe Paperclip::MediaTypeSpoofDetector do
     end
 
     it "logs info about the detected spoof" do
-      Paperclip.expects(:log).with('Content Type Spoof: Filename empty.html (image/jpg from Headers, ["text/html"] from Extension), content type discovered from file command: text/html. See documentation to allow this combination.')
+      expect(Paperclip).to receive(:log).with('Content Type Spoof: Filename empty.html (image/jpg from Headers, ["text/html"] from Extension), content type discovered from file command: text/html. See documentation to allow this combination.')
       spoofed?
     end
   end
@@ -108,12 +108,12 @@ describe Paperclip::MediaTypeSpoofDetector do
     let(:detector) { Paperclip::MediaTypeSpoofDetector.new(file, "html", "") }
 
     it "does work with the output of old versions of file" do
-      allow(Paperclip).to reject(:run).and_return("text/html charset=us-ascii")
+      allow(Paperclip).to receive(:run).and_return("text/html charset=us-ascii")
       expect(detector.send(:type_from_file_command)).to eq("text/html")
     end
 
     it "does work with the output of new versions of file" do
-      allow(Paperclip).to reject(:run).and_return("text/html; charset=us-ascii")
+      allow(Paperclip).to receive(:run).and_return("text/html; charset=us-ascii")
       expect(detector.send(:type_from_file_command)).to eq("text/html")
     end
   end

--- a/spec/paperclip/paperclip_spec.rb
+++ b/spec/paperclip/paperclip_spec.rb
@@ -4,7 +4,7 @@ describe Paperclip do
   context ".run" do
     before do
       Paperclip.options[:log_command] = false
-      expect(Terrapin::CommandLine).to receive(:new).with("convert", "stuff", {}).and_return(spy(:run))
+      expect(Terrapin::CommandLine).to receive(:new).with("convert", "stuff", {}).and_return(double(run: nil))
       @original_command_line_path = Terrapin::CommandLine.path
     end
 
@@ -24,7 +24,7 @@ describe Paperclip do
     end
 
     it "does not duplicate Terrapin::CommandLine.path on multiple runs" do
-      expect(Terrapin::CommandLine).to receive(:new).with("convert", "more_stuff", {}).and_return(spy(:run))
+      expect(Terrapin::CommandLine).to receive(:new).with("convert", "more_stuff", {}).and_return(double(run: nil))
       Terrapin::CommandLine.path = nil
       Paperclip.options[:command_path] = "/opt/my_app/bin"
       Paperclip.run("convert", "stuff")
@@ -63,7 +63,7 @@ describe Paperclip do
   context "Calling Paperclip.run with a logger" do
     it "passes the defined logger if :log_command is set" do
       Paperclip.options[:log_command] = true
-      expect(Terrapin::CommandLine).to receive(:new).with("convert", "stuff", logger: Paperclip.logger).and_return(spy(:run))
+      expect(Terrapin::CommandLine).to receive(:new).with("convert", "stuff", logger: Paperclip.logger).and_return(double(run: nil))
       Paperclip.run("convert", "stuff")
     end
   end

--- a/spec/paperclip/paperclip_spec.rb
+++ b/spec/paperclip/paperclip_spec.rb
@@ -4,7 +4,7 @@ describe Paperclip do
   context ".run" do
     before do
       Paperclip.options[:log_command] = false
-      Terrapin::CommandLine.expects(:new).with("convert", "stuff", {}).returns(stub(:run))
+      expect(Terrapin::CommandLine).to receive(:new).with("convert", "stuff", {}).and_return(spy(:run))
       @original_command_line_path = Terrapin::CommandLine.path
     end
 
@@ -24,7 +24,7 @@ describe Paperclip do
     end
 
     it "does not duplicate Terrapin::CommandLine.path on multiple runs" do
-      Terrapin::CommandLine.expects(:new).with("convert", "more_stuff", {}).returns(stub(:run))
+      expect(Terrapin::CommandLine).to receive(:new).with("convert", "more_stuff", {}).and_return(spy(:run))
       Terrapin::CommandLine.path = nil
       Paperclip.options[:command_path] = "/opt/my_app/bin"
       Paperclip.run("convert", "stuff")
@@ -63,7 +63,7 @@ describe Paperclip do
   context "Calling Paperclip.run with a logger" do
     it "passes the defined logger if :log_command is set" do
       Paperclip.options[:log_command] = true
-      Terrapin::CommandLine.expects(:new).with("convert", "stuff", logger: Paperclip.logger).returns(stub(:run))
+      expect(Terrapin::CommandLine).to receive(:new).with("convert", "stuff", logger: Paperclip.logger).and_return(spy(:run))
       Paperclip.run("convert", "stuff")
     end
   end

--- a/spec/paperclip/processor_helpers_spec.rb
+++ b/spec/paperclip/processor_helpers_spec.rb
@@ -8,13 +8,13 @@ describe Paperclip::ProcessorHelpers do
         main_path = 'main_path'
         alternate_path = 'alternate_path'
 
-        Rails.stubs(:root).returns(pathname)
-        File.expects(:expand_path).with(pathname.join('lib/paperclip', 'custom.rb')).returns(main_path)
-        File.expects(:expand_path).with(pathname.join('lib/paperclip_processors', 'custom.rb')).returns(alternate_path)
-        File.expects(:exist?).with(main_path).returns(true)
-        File.expects(:exist?).with(alternate_path).returns(false)
+        allow(Rails).to receive(:root).and_return(pathname)
+        expect(File).to receive(:expand_path).with(pathname.join('lib/paperclip', 'custom.rb')).and_return(main_path)
+        expect(File).to receive(:expand_path).with(pathname.join('lib/paperclip_processors', 'custom.rb')).and_return(alternate_path)
+        expect(File).to receive(:exist?).with(main_path).and_return(true)
+        expect(File).to receive(:exist?).with(alternate_path).and_return(false)
 
-        Paperclip.expects(:require).with(main_path)
+        expect(Paperclip).to receive(:require).with(main_path)
 
         Paperclip.load_processor(:custom)
       end
@@ -26,13 +26,13 @@ describe Paperclip::ProcessorHelpers do
         main_path = 'main_path'
         alternate_path = 'alternate_path'
 
-        Rails.stubs(:root).returns(pathname)
-        File.expects(:expand_path).with(pathname.join('lib/paperclip', 'custom.rb')).returns(main_path)
-        File.expects(:expand_path).with(pathname.join('lib/paperclip_processors', 'custom.rb')).returns(alternate_path)
-        File.expects(:exist?).with(main_path).returns(false)
-        File.expects(:exist?).with(alternate_path).returns(true)
+        allow(Rails).to receive(:root).and_return(pathname)
+        expect(File).to receive(:expand_path).with(pathname.join('lib/paperclip', 'custom.rb')).and_return(main_path)
+        expect(File).to receive(:expand_path).with(pathname.join('lib/paperclip_processors', 'custom.rb')).and_return(alternate_path)
+        expect(File).to receive(:exist?).with(main_path).and_return(false)
+        expect(File).to receive(:exist?).with(alternate_path).and_return(true)
 
-        Paperclip.expects(:require).with(alternate_path)
+        expect(Paperclip).to receive(:require).with(alternate_path)
 
         Paperclip.load_processor(:custom)
       end
@@ -44,11 +44,11 @@ describe Paperclip::ProcessorHelpers do
         main_path = 'main_path'
         alternate_path = 'alternate_path'
 
-        Rails.stubs(:root).returns(pathname)
-        File.stubs(:expand_path).with(pathname.join('lib/paperclip', 'custom.rb')).returns(main_path)
-        File.stubs(:expand_path).with(pathname.join('lib/paperclip_processors', 'custom.rb')).returns(alternate_path)
-        File.stubs(:exist?).with(main_path).returns(false)
-        File.stubs(:exist?).with(alternate_path).returns(false)
+        allow(Rails).to receive(:root).and_return(pathname)
+        allow(File).to receive(:expand_path).with(pathname.join('lib/paperclip', 'custom.rb')).and_return(main_path)
+        allow(File).to receive(:expand_path).with(pathname.join('lib/paperclip_processors', 'custom.rb')).and_return(alternate_path)
+        allow(File).to receive(:exist?).with(main_path).and_return(false)
+        allow(File).to receive(:exist?).with(alternate_path).and_return(false)
 
         assert_raises(LoadError) { Paperclip.processor(:custom) }
       end

--- a/spec/paperclip/processor_spec.rb
+++ b/spec/paperclip/processor_spec.rb
@@ -2,16 +2,16 @@ require 'spec_helper'
 
 describe Paperclip::Processor do
   it "instantiates and call #make when sent #make to the class" do
-    processor = mock
-    processor.expects(:make).with()
-    Paperclip::Processor.expects(:new).with(:one, :two, :three).returns(processor)
+    processor = spy
+    expect(processor).to receive(:make)
+    expect(Paperclip::Processor).to receive(:new).with(:one, :two, :three).and_return(processor)
     Paperclip::Processor.make(:one, :two, :three)
   end
 
   context "Calling #convert" do
     it "runs the convert command with Terrapin" do
       Paperclip.options[:log_command] = false
-      Terrapin::CommandLine.expects(:new).with("convert", "stuff", {}).returns(stub(:run))
+      allow(Terrapin::CommandLine).to receive(:new).with("convert", "stuff", {}).and_return(spy(:run))
       Paperclip::Processor.new('filename').convert("stuff")
     end
   end
@@ -19,7 +19,7 @@ describe Paperclip::Processor do
   context "Calling #identify" do
     it "runs the identify command with Terrapin" do
       Paperclip.options[:log_command] = false
-      Terrapin::CommandLine.expects(:new).with("identify", "stuff", {}).returns(stub(:run))
+      allow(Terrapin::CommandLine).to receive(:new).with("identify", "stuff", {}).and_return(spy(:run))
       Paperclip::Processor.new('filename').identify("stuff")
     end
   end

--- a/spec/paperclip/processor_spec.rb
+++ b/spec/paperclip/processor_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Paperclip::Processor do
   it "instantiates and call #make when sent #make to the class" do
-    processor = spy
+    processor = double
     expect(processor).to receive(:make)
     expect(Paperclip::Processor).to receive(:new).with(:one, :two, :three).and_return(processor)
     Paperclip::Processor.make(:one, :two, :three)
@@ -11,7 +11,7 @@ describe Paperclip::Processor do
   context "Calling #convert" do
     it "runs the convert command with Terrapin" do
       Paperclip.options[:log_command] = false
-      allow(Terrapin::CommandLine).to receive(:new).with("convert", "stuff", {}).and_return(spy(:run))
+      expect(Terrapin::CommandLine).to receive(:new).with("convert", "stuff", {}).and_return(double(run: nil))
       Paperclip::Processor.new('filename').convert("stuff")
     end
   end
@@ -19,7 +19,7 @@ describe Paperclip::Processor do
   context "Calling #identify" do
     it "runs the identify command with Terrapin" do
       Paperclip.options[:log_command] = false
-      allow(Terrapin::CommandLine).to receive(:new).with("identify", "stuff", {}).and_return(spy(:run))
+      expect(Terrapin::CommandLine).to receive(:new).with("identify", "stuff", {}).and_return(double(run: nil))
       Paperclip::Processor.new('filename').identify("stuff")
     end
   end

--- a/spec/paperclip/rake_spec.rb
+++ b/spec/paperclip/rake_spec.rb
@@ -13,7 +13,7 @@ describe Rake do
       @valid_instance = Dummy.new
       allow(@valid_instance.avatar).to receive(:reprocess!)
       allow(Paperclip::Task).to receive(:log_error)
-      allow(Paperclip).to receive(:each_instance_with_attachment).and_yield @bogus_instance, @valid_instance
+      allow(Paperclip).to receive(:each_instance_with_attachment).and_yield(@bogus_instance).and_yield(@valid_instance)
     end
     context "when there is an exception in reprocess!" do
       before do

--- a/spec/paperclip/rake_spec.rb
+++ b/spec/paperclip/rake_spec.rb
@@ -6,18 +6,18 @@ describe Rake do
   context "calling `rake paperclip:refresh:thumbnails`" do
     before do
       rebuild_model
-      Paperclip::Task.stubs(:obtain_class).returns('Dummy')
+      allow(Paperclip::Task).to receive(:obtain_class).and_return('Dummy')
       @bogus_instance = Dummy.new
       @bogus_instance.id = 'some_id'
-      @bogus_instance.avatar.stubs(:reprocess!)
+      allow(@bogus_instance.avatar).to receive(:reprocess!)
       @valid_instance = Dummy.new
-      @valid_instance.avatar.stubs(:reprocess!)
-      Paperclip::Task.stubs(:log_error)
-      Paperclip.stubs(:each_instance_with_attachment).multiple_yields @bogus_instance, @valid_instance
+      allow(@valid_instance.avatar).to receive(:reprocess!)
+      allow(Paperclip::Task).to receive(:log_error)
+      allow(Paperclip).to receive(:each_instance_with_attachment).and_yield @bogus_instance, @valid_instance
     end
     context "when there is an exception in reprocess!" do
       before do
-        @bogus_instance.avatar.stubs(:reprocess!).raises
+        allow(@bogus_instance.avatar).to receive(:reprocess!).and_raise
       end
 
       it "catches the exception" do
@@ -27,28 +27,28 @@ describe Rake do
       end
 
       it "continues to the next instance" do
-        @valid_instance.avatar.expects(:reprocess!)
+        expect(@valid_instance.avatar).to receive(:reprocess!)
         ::Rake::Task['paperclip:refresh:thumbnails'].execute
       end
 
       it "prints the exception" do
         exception_msg = 'Some Exception'
-        @bogus_instance.avatar.stubs(:reprocess!).raises(exception_msg)
-        Paperclip::Task.expects(:log_error).with do |str|
+        allow(@bogus_instance.avatar).to receive(:reprocess!).and_raise(exception_msg)
+        expect(Paperclip::Task).to receive(:log_error) do |str|
           str.match exception_msg
         end
         ::Rake::Task['paperclip:refresh:thumbnails'].execute
       end
 
       it "prints the class name" do
-        Paperclip::Task.expects(:log_error).with do |str|
+        expect(Paperclip::Task).to receive(:log_error) do |str|
           str.match 'Dummy'
         end
         ::Rake::Task['paperclip:refresh:thumbnails'].execute
       end
 
       it "prints the instance ID" do
-        Paperclip::Task.expects(:log_error).with do |str|
+        expect(Paperclip::Task).to receive(:log_error) do |str|
           str.match "ID #{@bogus_instance.id}"
         end
         ::Rake::Task['paperclip:refresh:thumbnails'].execute
@@ -57,35 +57,35 @@ describe Rake do
 
     context "when there is an error in reprocess!" do
       before do
-        @errors = mock('errors')
-        @errors.stubs(:full_messages).returns([''])
-        @errors.stubs(:blank?).returns(false)
-        @bogus_instance.stubs(:errors).returns(@errors)
+        @errors = spy('errors')
+        allow(@errors).to receive(:full_messages).and_return([''])
+        allow(@errors).to receive(:blank?).and_return(false)
+        allow(@bogus_instance).to receive(:errors).and_return(@errors)
       end
 
       it "continues to the next instance" do
-        @valid_instance.avatar.expects(:reprocess!)
+        expect(@valid_instance.avatar).to receive(:reprocess!)
         ::Rake::Task['paperclip:refresh:thumbnails'].execute
       end
 
       it "prints the error" do
         error_msg = 'Some Error'
-        @errors.stubs(:full_messages).returns([error_msg])
-        Paperclip::Task.expects(:log_error).with do |str|
+        allow(@errors).to receive(:full_messages).and_return([error_msg])
+        expect(Paperclip::Task).to receive(:log_error) do |str|
           str.match error_msg
         end
         ::Rake::Task['paperclip:refresh:thumbnails'].execute
       end
 
       it "prints the class name" do
-        Paperclip::Task.expects(:log_error).with do |str|
+        expect(Paperclip::Task).to receive(:log_error) do |str|
           str.match 'Dummy'
         end
         ::Rake::Task['paperclip:refresh:thumbnails'].execute
       end
 
       it "prints the instance ID" do
-        Paperclip::Task.expects(:log_error).with do |str|
+        expect(Paperclip::Task).to receive(:log_error) do |str|
           str.match "ID #{@bogus_instance.id}"
         end
         ::Rake::Task['paperclip:refresh:thumbnails'].execute
@@ -96,7 +96,7 @@ describe Rake do
   context "Paperclip::Task.log_error method" do
     it "prints its argument to STDERR" do
       msg = 'Some Message'
-      $stderr.expects(:puts).with(msg)
+      expect($stderr).to receive(:puts).with(msg)
       Paperclip::Task.log_error(msg)
     end
   end

--- a/spec/paperclip/rake_spec.rb
+++ b/spec/paperclip/rake_spec.rb
@@ -57,7 +57,7 @@ describe Rake do
 
     context "when there is an error in reprocess!" do
       before do
-        @errors = spy('errors')
+        @errors = double('errors')
         allow(@errors).to receive(:full_messages).and_return([''])
         allow(@errors).to receive(:blank?).and_return(false)
         allow(@bogus_instance).to receive(:errors).and_return(@errors)

--- a/spec/paperclip/storage/fog_spec.rb
+++ b/spec/paperclip/storage/fog_spec.rb
@@ -191,7 +191,7 @@ describe Paperclip::Storage::Fog do
       end
 
       it "passes the content type to the Fog::Storage::AWS::Files instance" do
-        Fog::Storage::AWS::Files.any_instance.expects(:create).with do |hash|
+        allow_any_instance_of(Fog::Storage::AWS::Files).to receive(:create).with do |hash|
           hash[:content_type]
         end
         @dummy.save
@@ -372,7 +372,7 @@ describe Paperclip::Storage::Fog do
       end
 
       context "with a valid bucket name for a subdomain" do
-        before { @dummy.stubs(:new_record?).returns(false) }
+        before { allow(@dummy).to receive(:new_record?).and_return(false) }
 
         it "provides an url in subdomain style" do
           assert_match(/^https:\/\/papercliptests.s3.amazonaws.com\/avatars\/5k.png/, @dummy.avatar.url)
@@ -437,7 +437,7 @@ describe Paperclip::Storage::Fog do
           @dynamic_fog_directory = 'dynamicpaperclip'
           rebuild_model(@options.merge(fog_directory: lambda { |attachment| attachment.instance.bucket_name }))
           @dummy = Dummy.new
-          @dummy.stubs(:bucket_name).returns(@dynamic_fog_directory)
+          allow(@dummy).to receive(:bucket_name).and_return(@dynamic_fog_directory)
           @dummy.avatar = @file
           @dummy.save
         end
@@ -455,7 +455,7 @@ describe Paperclip::Storage::Fog do
         before do
           rebuild_model(@options.merge(fog_host: lambda { |attachment| attachment.instance.fog_host }))
           @dummy = Dummy.new
-          @dummy.stubs(:fog_host).returns('http://dynamicfoghost.com')
+          allow(@dummy).to receive(:fog_host).and_return('http://dynamicfoghost.com')
           @dummy.avatar = @file
           @dummy.save
         end
@@ -506,7 +506,7 @@ describe Paperclip::Storage::Fog do
           }
           rebuild_model(@options.merge(fog_credentials: lambda { |attachment| attachment.instance.fog_credentials }))
           @dummy = Dummy.new
-          @dummy.stubs(:fog_credentials).returns(@dynamic_fog_credentials)
+          allow(@dummy).to receive(:fog_credentials).and_return(@dynamic_fog_credentials)
           @dummy.avatar = @file
           @dummy.save
         end
@@ -526,8 +526,8 @@ describe Paperclip::Storage::Fog do
         end
 
         it "applies the options to the fog #create call" do
-          files = stub
-          @dummy.avatar.stubs(:directory).returns stub(files: files)
+          files = spy
+          allow(@dummy.avatar).to receive(:directory).and_return stub(files: files)
           files.expects(:create).with(
             has_entries(multipart_chunk_size: 104857600),
           )
@@ -551,7 +551,7 @@ describe Paperclip::Storage::Fog do
       @file = File.new(fixture_file('5k.png'), 'rb')
       @dummy = Dummy.new
       @dummy.avatar = @file
-      @dummy.stubs(:new_record?).returns(false)
+      allow(@dummy).to receive(:new_record?).and_return(false)
     end
 
     after do

--- a/spec/paperclip/storage/fog_spec.rb
+++ b/spec/paperclip/storage/fog_spec.rb
@@ -191,7 +191,7 @@ describe Paperclip::Storage::Fog do
       end
 
       it "passes the content type to the Fog::Storage::AWS::Files instance" do
-        allow_any_instance_of(Fog::Storage::AWS::Files).to receive(:create) do |hash|
+        allow(Fog::Storage::AWS::Files.any_instance).to receive(:create) do |hash|
           hash[:content_type]
         end
         @dummy.save

--- a/spec/paperclip/storage/fog_spec.rb
+++ b/spec/paperclip/storage/fog_spec.rb
@@ -526,10 +526,10 @@ describe Paperclip::Storage::Fog do
         end
 
         it "applies the options to the fog #create call" do
-          files = spy
-          allow(@dummy.avatar).to receive(:directory).and_return spy(files: files)
-          files.expects(:create).with(
-            has_entries(multipart_chunk_size: 104857600),
+          files = double
+          allow(@dummy.avatar).to receive(:directory).and_return double(files: files)
+          expect(files).to receive(:create).with(
+            hash_including(multipart_chunk_size: 104857600),
           )
           @dummy.save
         end

--- a/spec/paperclip/storage/fog_spec.rb
+++ b/spec/paperclip/storage/fog_spec.rb
@@ -191,7 +191,7 @@ describe Paperclip::Storage::Fog do
       end
 
       it "passes the content type to the Fog::Storage::AWS::Files instance" do
-        allow_any_instance_of(Fog::Storage::AWS::Files).to receive(:create).with do |hash|
+        allow_any_instance_of(Fog::Storage::AWS::Files).to receive(:create) do |hash|
           hash[:content_type]
         end
         @dummy.save
@@ -527,7 +527,7 @@ describe Paperclip::Storage::Fog do
 
         it "applies the options to the fog #create call" do
           files = spy
-          allow(@dummy.avatar).to receive(:directory).and_return stub(files: files)
+          allow(@dummy.avatar).to receive(:directory).and_return spy(files: files)
           files.expects(:create).with(
             has_entries(multipart_chunk_size: 104857600),
           )

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -920,7 +920,7 @@ describe Paperclip::Storage::S3 do
         before do
           expect_any_instance_of(Aws::S3::Bucket).to receive(:create)
           allow_any_instance_of(Aws::S3::Object).to receive(:upload_file).
-            and_raise(Aws::S3::Errors::NoSuchBucket.new(double, double(status: 404, body: "<foo/>")))
+            and_raise(Aws::S3::Errors::NoSuchBucket.new(spy, spy(status: 404, body: "<foo/>")))
           allow_any_instance_of(Aws::S3::Object).to receive(:upload_file).and_return(nil)
           @dummy.save
         end

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -110,7 +110,7 @@ describe Paperclip::Storage::S3 do
         url: ":s3_path_url"
       @dummy = Dummy.new
       @dummy.avatar = stringy_file
-      @dummy.stubs(:new_record?).returns(false)
+      allow(@dummy).to receive(:new_record?).and_return(false)
     end
 
     it "returns a url based on an S3 path" do
@@ -151,7 +151,7 @@ describe Paperclip::Storage::S3 do
         path: ":attachment/:basename:dotextension"
       @dummy = Dummy.new
       @dummy.avatar = stringy_file
-      @dummy.stubs(:new_record?).returns(false)
+      allow(@dummy).to receive(:new_record?).and_return(false)
     end
 
     it "returns a url based on an S3 path" do
@@ -168,7 +168,7 @@ describe Paperclip::Storage::S3 do
         path: ":attachment/:basename:dotextension"
       @dummy = Dummy.new
       @dummy.avatar = stringy_file
-      @dummy.stubs(:new_record?).returns(false)
+      allow(@dummy).to receive(:new_record?).and_return(false)
     end
 
     it "returns a protocol-relative URL" do
@@ -185,7 +185,7 @@ describe Paperclip::Storage::S3 do
         path: ":attachment/:basename:dotextension"
       @dummy = Dummy.new
       @dummy.avatar = stringy_file
-      @dummy.stubs(:new_record?).returns(false)
+      allow(@dummy).to receive(:new_record?).and_return(false)
     end
 
     it "returns a url based on an S3 path" do
@@ -202,7 +202,7 @@ describe Paperclip::Storage::S3 do
         path: ":attachment/:basename:dotextension"
       @dummy = Dummy.new
       @dummy.avatar = stringy_file
-      @dummy.stubs(:new_record?).returns(false)
+      allow(@dummy).to receive(:new_record?).and_return(false)
     end
 
     it "returns a url based on an S3 path" do
@@ -248,7 +248,7 @@ describe Paperclip::Storage::S3 do
         s3_region: "ap-northeast-1"
       @dummy = Dummy.new
       @dummy.avatar = stringy_file
-      @dummy.stubs(:new_record?).returns(false)
+      allow(@dummy).to receive(:new_record?).and_return(false)
     end
 
     it "returns a url based on an :s3_host_name path" do
@@ -273,7 +273,7 @@ describe Paperclip::Storage::S3 do
         attr_accessor :value
       end
       @dummy.avatar = stringy_file
-      @dummy.stubs(:new_record?).returns(false)
+      allow(@dummy).to receive(:new_record?).and_return(false)
     end
 
     it "uses s3_host_name as a proc if available" do
@@ -295,7 +295,7 @@ describe Paperclip::Storage::S3 do
         )
         @dummy = Dummy.new
         @dummy.avatar = stringy_file
-        @dummy.stubs(:new_record?).returns(false)
+        allow(@dummy).to receive(:new_record?).and_return(false)
       end
 
       it "returns a url based on an :s3_host_name path" do
@@ -321,7 +321,7 @@ describe Paperclip::Storage::S3 do
         )
         @dummy = Dummy.new
         @dummy.avatar = stringy_file
-        @dummy.stubs(:new_record?).returns(false)
+        allow(@dummy).to receive(:new_record?).and_return(false)
       end
 
       it "returns a url based on an :s3_host_name path" do
@@ -349,7 +349,7 @@ describe Paperclip::Storage::S3 do
         File.open(fixture_file('5k.png'), 'rb') do |file|
           @dummy = Dummy.new
           @dummy.avatar = file
-          @dummy.stubs(:new_record?).returns(false)
+          allow(@dummy).to receive(:new_record?).and_return(false)
         end
     end
 
@@ -396,14 +396,14 @@ describe Paperclip::Storage::S3 do
         @dummy = Dummy.new
         @dummy.avatar = @file
 
-        object = stub
-        @dummy.avatar.stubs(:s3_object).with(:original).returns(object)
-        @dummy.avatar.stubs(:s3_object).with(:thumbnail).returns(object)
+        object = spy
+        allow(@dummy.avatar).to receive(:s3_object).with(:original).and_return(object)
+        allow(@dummy.avatar).to receive(:s3_object).with(:thumbnail).and_return(object)
 
-        object.expects(:upload_file)
+        expect(object).to receive(:upload_file)
           .with(anything, content_type: 'image/png',
                 acl: :"public-read")
-        object.expects(:upload_file)
+        expect(object).to receive(:upload_file)
           .with(anything, content_type: 'image/png',
                 acl: :"public-read",
                 cache_control: 'max-age=31557600')
@@ -438,30 +438,30 @@ describe Paperclip::Storage::S3 do
 
     context "reprocess" do
       before do
-        @object = stub
-        @dummy.avatar.stubs(:s3_object).with(:original).returns(@object)
-        @dummy.avatar.stubs(:s3_object).with(:thumb).returns(@object)
-        @object.stubs(:get).yields(@file.read)
-        @object.stubs(:exists?).returns(true)
+        @object = spy
+        allow(@dummy.avatar).to receive(:s3_object).with(:original).and_return(@object)
+        allow(@dummy.avatar).to receive(:s3_object).with(:thumb).and_return(@object)
+        allow(@object).to receive(:get).and_yield(@file.read)
+        allow(@object).to receive(:exists?).and_return(true)
       end
 
       it "uploads original" do
-        @object.expects(:upload_file).with(
+        expect(@object).to receive(:upload_file).with(
           anything,
           content_type: "image/png",
-          acl: :"public-read").returns(true)
-        @object.expects(:upload_file).with(
+          acl: :"public-read").and_return(true)
+        expect(@object).to receive(:upload_file).with(
           anything,
           content_type: "image/jpeg",
-          acl: :"public-read").returns(true)
+          acl: :"public-read").and_return(true)
         @dummy.avatar.reprocess!
       end
 
       it "doesn't upload original" do
-        @object.expects(:upload_file).with(
+        expect(@object).to receive(:upload_file).with(
           anything,
           content_type: "image/jpeg",
-          acl: :"public-read").returns(true)
+          acl: :"public-read").and_return(true)
         @dummy.avatar.reprocess!(:thumb)
       end
     end
@@ -482,7 +482,7 @@ describe Paperclip::Storage::S3 do
       File.open(fixture_file("spaced file.png"), "rb") do |file|
         @dummy = Dummy.new
         @dummy.avatar = file
-        @dummy.stubs(:new_record?).returns(false)
+        allow(@dummy).to receive(:new_record?).and_return(false)
       end
     end
 
@@ -515,7 +515,7 @@ describe Paperclip::Storage::S3 do
       @dummy = Dummy.new
       @dummy.avatar = file
       @dummy.save
-      @dummy.stubs(:new_record?).returns(false)
+      allow(@dummy).to receive(:new_record?).and_return(false)
     end
 
     it "returns a replaced version for path" do
@@ -536,7 +536,7 @@ describe Paperclip::Storage::S3 do
         url: ":s3_domain_url"
       @dummy = Dummy.new
       @dummy.avatar = stringy_file
-      @dummy.stubs(:new_record?).returns(false)
+      allow(@dummy).to receive(:new_record?).and_return(false)
     end
 
     it "returns a url based on an S3 subdomain" do
@@ -559,7 +559,7 @@ describe Paperclip::Storage::S3 do
         )
       @dummy = Dummy.new
       @dummy.avatar = stringy_file
-      @dummy.stubs(:new_record?).returns(false)
+      allow(@dummy).to receive(:new_record?).and_return(false)
     end
 
     it "returns a url based on the host_alias" do
@@ -585,7 +585,7 @@ describe Paperclip::Storage::S3 do
       )
       @dummy = Dummy.new
       @dummy.avatar = stringy_file
-      @dummy.stubs(:new_record?).returns(false)
+      allow(@dummy).to receive(:new_record?).and_return(false)
     end
 
     it "returns a url with the prefixes removed" do
@@ -610,7 +610,7 @@ describe Paperclip::Storage::S3 do
       end
       @dummy = Dummy.new
       @dummy.avatar = stringy_file
-      @dummy.stubs(:new_record?).returns(false)
+      allow(@dummy).to receive(:new_record?).and_return(false)
     end
 
     it "returns a url based on the host_alias" do
@@ -633,7 +633,7 @@ describe Paperclip::Storage::S3 do
         url: ":asset_host"
       @dummy = Dummy.new
       @dummy.avatar = stringy_file
-      @dummy.stubs(:new_record?).returns(false)
+      allow(@dummy).to receive(:new_record?).and_return(false)
     end
 
     it "returns a relative URL for Rails to calculate assets host" do
@@ -668,10 +668,10 @@ describe Paperclip::Storage::S3 do
         @dummy = Dummy.new
         @dummy.avatar = stringy_file
 
-        object = stub
-        @dummy.avatar.stubs(:s3_object).returns(object)
+        object = spy
+        allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
-        object.expects(:presigned_url).with(:get, expires_in: 3600)
+        expect(object).to receive(:presigned_url).with(:get, expires_in: 3600)
         @dummy.avatar.expiring_url
       end
     end
@@ -683,9 +683,9 @@ describe Paperclip::Storage::S3 do
         @dummy = Dummy.new
         @dummy.avatar = stringy_file
 
-        object = stub
-        @dummy.avatar.stubs(:s3_object).returns(object)
-        object.expects(:presigned_url)
+        object = spy
+        allow(@dummy.avatar).to receive(:s3_object).and_return(object)
+        expect(object).to receive(:presigned_url)
           .with(:get, expires_in: 3600,
                 response_content_disposition: "inline")
         @dummy.avatar.expiring_url
@@ -699,16 +699,16 @@ describe Paperclip::Storage::S3 do
         @dummy = Dummy.new
 
         @file = stringy_file
-        @file.stubs(:original_filename).returns("5k.png\n\n")
-        Paperclip.stubs(:run).returns('image/png')
-        @file.stubs(:content_type).returns("image/png\n\n")
-        @file.stubs(:to_tempfile).returns(@file)
+        allow(@file).to receive(:original_filename).and_return("5k.png\n\n")
+        allow(Paperclip).to receive(:run).and_return('image/png')
+        allow(@file).to receive(:content_type).and_return("image/png\n\n")
+        allow(@file).to receive(:to_tempfile).and_return(@file)
 
         @dummy.avatar = @file
 
-        object = stub
-        @dummy.avatar.stubs(:s3_object).returns(object)
-        object.expects(:presigned_url)
+        object = spy
+        allow(@dummy.avatar).to receive(:s3_object).and_return(object)
+        expect(object).to receive(:presigned_url)
           .with(:get, expires_in: 3600, response_content_type: "image/png")
         @dummy.avatar.expiring_url
       end
@@ -754,16 +754,16 @@ describe Paperclip::Storage::S3 do
     end
 
     it "generates a url for the thumb" do
-      object = stub
-      @dummy.avatar.stubs(:s3_object).with(:thumb).returns(object)
-      object.expects(:presigned_url).with(:get, expires_in: 1800)
+      object = spy
+      allow(@dummy.avatar).to receive(:s3_object).with(:thumb).and_return(object)
+      expect(object).to receive(:presigned_url).with(:get, expires_in: 1800)
       @dummy.avatar.expiring_url(1800, :thumb)
     end
 
     it "generates a url for the default style" do
-      object = stub
-      @dummy.avatar.stubs(:s3_object).with(:original).returns(object)
-      object.expects(:presigned_url).with(:get, expires_in: 1800)
+      object = spy
+      allow(@dummy.avatar).to receive(:s3_object).with(:original).and_return(object)
+      expect(object).to receive(:presigned_url).with(:get, expires_in: 1800)
       @dummy.avatar.expiring_url(1800)
     end
   end
@@ -862,27 +862,27 @@ describe Paperclip::Storage::S3 do
         @file = File.new(fixture_file('5k.png'), 'rb')
         @dummy = Dummy.new
         @dummy.avatar = @file
-        @dummy.stubs(:new_record?).returns(false)
+        allow(@dummy).to receive(:new_record?).and_return(false)
       end
 
       after { @file.close }
 
       it "does not get a bucket to get a URL" do
-        @dummy.avatar.expects(:s3).never
-        @dummy.avatar.expects(:s3_bucket).never
+        expect(@dummy.avatar).to_not receive(:s3)
+        expect(@dummy.avatar).to_not receive(:s3_bucket)
         assert_match %r{^//s3\.amazonaws\.com/testing/avatars/original/5k\.png}, @dummy.avatar.url
       end
 
       it "is rewound after flush_writes" do
         @dummy.avatar.instance_eval "def after_flush_writes; end"
-        @dummy.avatar.stubs(:s3_object).returns(stub(upload_file: true))
+        allow(@dummy.avatar).to receive(:s3_object).and_return(spy(upload_file: true))
         files = @dummy.avatar.queued_for_write.values.each(&:read)
         @dummy.save
         assert files.none?(&:eof?), "Expect all the files to be rewound."
       end
 
       it "is removed after after_flush_writes" do
-        @dummy.avatar.stubs(:s3_object).returns(stub(upload_file: true))
+        allow(@dummy.avatar).to receive(:s3_object).and_return(spy(upload_file: true))
         paths = @dummy.avatar.queued_for_write.values.map(&:path)
         @dummy.save
         assert paths.none?{ |path| File.exist?(path) },
@@ -890,10 +890,10 @@ describe Paperclip::Storage::S3 do
       end
 
       it "will retry to save again but back off on SlowDown" do
-        @dummy.avatar.stubs(:sleep)
-        Aws::S3::Object.any_instance.stubs(:upload_file).
-          raises(Aws::S3::Errors::SlowDown.new(stub,
-                                               stub(status: 503, body: "")))
+        allow(@dummy.avatar).to receive(:sleep)
+        allow_any_instance_of(Aws::S3::Object).to receive(:upload_file).
+          and_raise(Aws::S3::Errors::SlowDown.new(spy,
+                                               spy(status: 503, body: "")))
         expect {@dummy.save}.to raise_error(Aws::S3::Errors::SlowDown)
         expect(@dummy.avatar).to have_received(:sleep).with(1)
         expect(@dummy.avatar).to have_received(:sleep).with(2)
@@ -904,9 +904,9 @@ describe Paperclip::Storage::S3 do
 
       context "and saved" do
         before do
-          object = stub
-          @dummy.avatar.stubs(:s3_object).returns(object)
-          object.expects(:upload_file)
+          object = spy
+          allow(@dummy.avatar).to receive(:s3_object).and_return(object)
+          expect(object).to receive(:upload_file)
             .with(anything, content_type: 'image/png', acl: :"public-read")
           @dummy.save
         end
@@ -918,11 +918,11 @@ describe Paperclip::Storage::S3 do
 
       context "and saved without a bucket" do
         before do
-          Aws::S3::Bucket.any_instance.expects(:create)
-          Aws::S3::Object.any_instance.stubs(:upload_file).
-            raises(Aws::S3::Errors::NoSuchBucket
-                    .new(stub,
-                         stub(status: 404, body: "<foo/>"))).then.returns(nil)
+          allow_any_instance_of(Aws::S3::Bucket).to receive(:create)
+          allow_any_instance_of(Aws::S3::Object).to receive(:upload_file).
+            and_raise(Aws::S3::Errors::NoSuchBucket
+                    .new(spy,
+                         spy(status: 404, body: "<foo/>"))).then.and_return(nil)
           @dummy.save
         end
 
@@ -933,8 +933,8 @@ describe Paperclip::Storage::S3 do
 
       context "and remove" do
         before do
-          Aws::S3::Object.any_instance.stubs(:exists?).returns(true)
-          Aws::S3::Object.any_instance.stubs(:delete)
+          allow_any_instance_of(Aws::S3::Object).to receive(:exists?).and_return(true)
+          allow_any_instance_of(Aws::S3::Object).to receive(:delete)
           @dummy.destroy
         end
 
@@ -945,8 +945,8 @@ describe Paperclip::Storage::S3 do
 
       context 'that the file were missing' do
         before do
-          Aws::S3::Object.any_instance.stubs(:exists?)
-            .raises(Aws::S3::Errors::ServiceError.new("rspec stub raises",
+          allow_any_instance_of(Aws::S3::Object).to receive(:exists?)
+            .and_raise(Aws::S3::Errors::ServiceError.new("rspec stub raises",
                                                       "object exists?"))
         end
 
@@ -1052,10 +1052,10 @@ describe Paperclip::Storage::S3 do
 
       context "and saved" do
         before do
-          object = stub
-          @dummy.avatar.stubs(:s3_object).returns(object)
+          object = spy
+          allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
-          object.expects(:upload_file)
+          expect(object).to receive(:upload_file)
             .with(anything,
                   content_type: 'image/png',
                   acl: :"public-read",
@@ -1093,10 +1093,10 @@ describe Paperclip::Storage::S3 do
 
       context "and saved" do
         before do
-          object = stub
-          @dummy.avatar.stubs(:s3_object).returns(object)
+          object = spy
+          allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
-          object.expects(:upload_file)
+          expect(object).to receive(:upload_file)
             .with(anything,
                   content_type: 'image/png',
                   acl: :"public-read",
@@ -1134,10 +1134,10 @@ describe Paperclip::Storage::S3 do
 
       context "and saved" do
         before do
-          object = stub
-          @dummy.avatar.stubs(:s3_object).returns(object)
+          object = spy
+          allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
-          object.expects(:upload_file)
+          expect(object).to receive(:upload_file)
             .with(anything,
                   content_type: 'image/png',
                   acl: :"public-read",
@@ -1176,10 +1176,10 @@ describe Paperclip::Storage::S3 do
 
         context "and saved" do
           before do
-            object = stub
-            @dummy.avatar.stubs(:s3_object).returns(object)
+            object = spy
+            allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
-            object.expects(:upload_file)
+            expect(object).to receive(:upload_file)
               .with(anything,
                     content_type: 'image/png',
                     acl: :"public-read",
@@ -1222,9 +1222,9 @@ describe Paperclip::Storage::S3 do
 
         context "and saved" do
           before do
-            object = stub
+            object = spy
             [:thumb, :original].each do |style|
-              @dummy.avatar.stubs(:s3_object).with(style).returns(object)
+              allow(@dummy.avatar).to receive(:s3_object).with(style).and_return(object)
 
               expected_options = {
                 :content_type => "image/png",
@@ -1232,7 +1232,7 @@ describe Paperclip::Storage::S3 do
               }
               expected_options.merge!(:storage_class => :reduced_redundancy) if style == :thumb
 
-              object.expects(:upload_file)
+              expect(object).to receive(:upload_file)
                 .with(anything, expected_options)
             end
             @dummy.save
@@ -1271,11 +1271,11 @@ describe Paperclip::Storage::S3 do
 
         context "and saved" do
           before do
-            object = stub
+            object = spy
             [:thumb, :original].each do |style|
-              @dummy.avatar.stubs(:s3_object).with(style).returns(object)
+              allow(@dummy.avatar).to receive(:s3_object).with(style).and_return(object)
 
-              object.expects(:upload_file)
+              expect(object).to receive(:upload_file)
                 .with(anything, :content_type => "image/png",
                       acl: :"public-read",
                       :storage_class => :reduced_redundancy)
@@ -1315,10 +1315,10 @@ describe Paperclip::Storage::S3 do
 
         context "and saved" do
           before do
-            object = stub
-            @dummy.avatar.stubs(:s3_object).returns(object)
+            object = spy
+            allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
-            object.expects(:upload_file)
+            expect(object).to receive(:upload_file)
               .with(anything, :content_type => "image/png", acl: :"public-read")
             @dummy.save
           end
@@ -1354,10 +1354,10 @@ describe Paperclip::Storage::S3 do
 
       context "and saved" do
         before do
-          object = stub
-          @dummy.avatar.stubs(:s3_object).returns(object)
+          object = spy
+          allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
-          object.expects(:upload_file)
+          expect(object).to receive(:upload_file)
             .with(anything, content_type: "image/png",
                   acl: :"public-read",
                   server_side_encryption: "AES256")
@@ -1394,10 +1394,10 @@ describe Paperclip::Storage::S3 do
 
       context "and saved" do
         before do
-          object = stub
-          @dummy.avatar.stubs(:s3_object).returns(object)
+          object = spy
+          allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
-          object.expects(:upload_file)
+          expect(object).to receive(:upload_file)
             .with(anything,
                   content_type: "image/png",
                   acl: :"public-read",
@@ -1488,10 +1488,10 @@ describe Paperclip::Storage::S3 do
 
         context "and saved" do
           before do
-            object = stub
-            @dummy.avatar.stubs(:s3_object).returns(object)
+            object = spy
+            allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
-            object.expects(:upload_file)
+            expect(object).to receive(:upload_file)
               .with(anything, content_type: "image/png", acl: :"public-read")
             @dummy.save
           end
@@ -1526,10 +1526,10 @@ describe Paperclip::Storage::S3 do
 
         context "and saved" do
           before do
-            object = stub
-            @dummy.avatar.stubs(:s3_object).returns(object)
+            object = spy
+            allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
-            object.expects(:upload_file)
+            expect(object).to receive(:upload_file)
               .with(anything, content_type: "image/png", acl: :private)
             @dummy.save
           end
@@ -1571,10 +1571,10 @@ describe Paperclip::Storage::S3 do
         context "and saved" do
           before do
             [:thumb, :original].each do |style|
-              object = stub
-              @dummy.avatar.stubs(:s3_object).with(style).returns(object)
+              object = spy
+              allow(@dummy.avatar).to receive(:s3_object).with(style).and_return(object)
 
-              object.expects(:upload_file)
+              expect(object).to receive(:upload_file)
                 .with(anything,
                       content_type: "image/png",
                       acl: style == :thumb ? :public_read : :private)
@@ -1633,7 +1633,7 @@ describe Paperclip::Storage::S3 do
       before do
         @file = File.new(fixture_file('5k.png'), 'rb')
         @dummy = Dummy.new
-        @dummy.stubs(name: 'Custom Avatar Name.png')
+        allow(@dummy).to receive(:name).with('Custom Avatar Name.png')
         @dummy.avatar = @file
       end
 
@@ -1642,10 +1642,10 @@ describe Paperclip::Storage::S3 do
       context "and saved" do
         before do
           [:thumb, :original].each do |style|
-            object = stub
-            @dummy.avatar.stubs(:s3_object).with(style).returns(object)
+            object = spy
+            allow(@dummy.avatar).to receive(:s3_object).with(style).and_return(object)
 
-            object.expects(:upload_file)
+            expect(object).to receive(:upload_file)
               .with(anything,
                     content_type: "image/png",
                     acl: :"public-read",

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -918,9 +918,8 @@ describe Paperclip::Storage::S3 do
 
       context "and saved without a bucket" do
         before do
-          expect_any_instance_of(Aws::S3::Bucket).to receive(:create)
           allow_any_instance_of(Aws::S3::Object).to receive(:upload_file).
-            and_raise(Aws::S3::Errors::NoSuchBucket.new(spy, spy(status: 404, body: "<foo/>")))
+            and_raise(Aws::S3::Errors::NoSuchBucket.new(double, double(status: 404, body: "<foo/>", empty?: false)))
           allow_any_instance_of(Aws::S3::Object).to receive(:upload_file).and_return(nil)
           @dummy.save
         end
@@ -1632,7 +1631,7 @@ describe Paperclip::Storage::S3 do
       before do
         @file = File.new(fixture_file('5k.png'), 'rb')
         @dummy = Dummy.new
-        allow(@dummy).to receive(:name).with('Custom Avatar Name.png')
+        allow(@dummy).to receive(:name).and_return('Custom Avatar Name.png')
         @dummy.avatar = @file
       end
 

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -396,7 +396,7 @@ describe Paperclip::Storage::S3 do
         @dummy = Dummy.new
         @dummy.avatar = @file
 
-        object = spy
+        object = double
         allow(@dummy.avatar).to receive(:s3_object).with(:original).and_return(object)
         allow(@dummy.avatar).to receive(:s3_object).with(:thumbnail).and_return(object)
 
@@ -438,7 +438,7 @@ describe Paperclip::Storage::S3 do
 
     context "reprocess" do
       before do
-        @object = spy
+        @object = double
         allow(@dummy.avatar).to receive(:s3_object).with(:original).and_return(@object)
         allow(@dummy.avatar).to receive(:s3_object).with(:thumb).and_return(@object)
         allow(@object).to receive(:get).and_yield(@file.read)
@@ -668,7 +668,7 @@ describe Paperclip::Storage::S3 do
         @dummy = Dummy.new
         @dummy.avatar = stringy_file
 
-        object = spy
+        object = double
         allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
         expect(object).to receive(:presigned_url).with(:get, expires_in: 3600)
@@ -683,7 +683,7 @@ describe Paperclip::Storage::S3 do
         @dummy = Dummy.new
         @dummy.avatar = stringy_file
 
-        object = spy
+        object = double
         allow(@dummy.avatar).to receive(:s3_object).and_return(object)
         expect(object).to receive(:presigned_url)
           .with(:get, expires_in: 3600,
@@ -706,7 +706,7 @@ describe Paperclip::Storage::S3 do
 
         @dummy.avatar = @file
 
-        object = spy
+        object = double
         allow(@dummy.avatar).to receive(:s3_object).and_return(object)
         expect(object).to receive(:presigned_url)
           .with(:get, expires_in: 3600, response_content_type: "image/png")
@@ -754,14 +754,14 @@ describe Paperclip::Storage::S3 do
     end
 
     it "generates a url for the thumb" do
-      object = spy
+      object = double
       allow(@dummy.avatar).to receive(:s3_object).with(:thumb).and_return(object)
       expect(object).to receive(:presigned_url).with(:get, expires_in: 1800)
       @dummy.avatar.expiring_url(1800, :thumb)
     end
 
     it "generates a url for the default style" do
-      object = spy
+      object = double
       allow(@dummy.avatar).to receive(:s3_object).with(:original).and_return(object)
       expect(object).to receive(:presigned_url).with(:get, expires_in: 1800)
       @dummy.avatar.expiring_url(1800)
@@ -875,14 +875,14 @@ describe Paperclip::Storage::S3 do
 
       it "is rewound after flush_writes" do
         @dummy.avatar.instance_eval "def after_flush_writes; end"
-        allow(@dummy.avatar).to receive(:s3_object).and_return(spy(upload_file: true))
+        allow(@dummy.avatar).to receive(:s3_object).and_return(double(upload_file: true))
         files = @dummy.avatar.queued_for_write.values.each(&:read)
         @dummy.save
         assert files.none?(&:eof?), "Expect all the files to be rewound."
       end
 
       it "is removed after after_flush_writes" do
-        allow(@dummy.avatar).to receive(:s3_object).and_return(spy(upload_file: true))
+        allow(@dummy.avatar).to receive(:s3_object).and_return(double(upload_file: true))
         paths = @dummy.avatar.queued_for_write.values.map(&:path)
         @dummy.save
         assert paths.none?{ |path| File.exist?(path) },
@@ -904,7 +904,7 @@ describe Paperclip::Storage::S3 do
 
       context "and saved" do
         before do
-          object = spy
+          object = double
           allow(@dummy.avatar).to receive(:s3_object).and_return(object)
           expect(object).to receive(:upload_file)
             .with(anything, content_type: 'image/png', acl: :"public-read")
@@ -918,11 +918,10 @@ describe Paperclip::Storage::S3 do
 
       context "and saved without a bucket" do
         before do
-          allow_any_instance_of(Aws::S3::Bucket).to receive(:create)
+          expect_any_instance_of(Aws::S3::Bucket).to receive(:create)
           allow_any_instance_of(Aws::S3::Object).to receive(:upload_file).
-            and_raise(Aws::S3::Errors::NoSuchBucket
-                    .new(spy,
-                         spy(status: 404, body: "<foo/>"))).then.and_return(nil)
+            and_raise(Aws::S3::Errors::NoSuchBucket.new(double, double(status: 404, body: "<foo/>")))
+          allow_any_instance_of(Aws::S3::Object).to receive(:upload_file).and_return(nil)
           @dummy.save
         end
 
@@ -1052,7 +1051,7 @@ describe Paperclip::Storage::S3 do
 
       context "and saved" do
         before do
-          object = spy
+          object = double
           allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
           expect(object).to receive(:upload_file)
@@ -1093,7 +1092,7 @@ describe Paperclip::Storage::S3 do
 
       context "and saved" do
         before do
-          object = spy
+          object = double
           allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
           expect(object).to receive(:upload_file)
@@ -1134,7 +1133,7 @@ describe Paperclip::Storage::S3 do
 
       context "and saved" do
         before do
-          object = spy
+          object = double
           allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
           expect(object).to receive(:upload_file)
@@ -1176,7 +1175,7 @@ describe Paperclip::Storage::S3 do
 
         context "and saved" do
           before do
-            object = spy
+            object = double
             allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
             expect(object).to receive(:upload_file)
@@ -1222,7 +1221,7 @@ describe Paperclip::Storage::S3 do
 
         context "and saved" do
           before do
-            object = spy
+            object = double
             [:thumb, :original].each do |style|
               allow(@dummy.avatar).to receive(:s3_object).with(style).and_return(object)
 
@@ -1271,7 +1270,7 @@ describe Paperclip::Storage::S3 do
 
         context "and saved" do
           before do
-            object = spy
+            object = double
             [:thumb, :original].each do |style|
               allow(@dummy.avatar).to receive(:s3_object).with(style).and_return(object)
 
@@ -1315,7 +1314,7 @@ describe Paperclip::Storage::S3 do
 
         context "and saved" do
           before do
-            object = spy
+            object = double
             allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
             expect(object).to receive(:upload_file)
@@ -1354,7 +1353,7 @@ describe Paperclip::Storage::S3 do
 
       context "and saved" do
         before do
-          object = spy
+          object = double
           allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
           expect(object).to receive(:upload_file)
@@ -1394,7 +1393,7 @@ describe Paperclip::Storage::S3 do
 
       context "and saved" do
         before do
-          object = spy
+          object = double
           allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
           expect(object).to receive(:upload_file)
@@ -1488,7 +1487,7 @@ describe Paperclip::Storage::S3 do
 
         context "and saved" do
           before do
-            object = spy
+            object = double
             allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
             expect(object).to receive(:upload_file)
@@ -1526,7 +1525,7 @@ describe Paperclip::Storage::S3 do
 
         context "and saved" do
           before do
-            object = spy
+            object = double
             allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
             expect(object).to receive(:upload_file)
@@ -1571,7 +1570,7 @@ describe Paperclip::Storage::S3 do
         context "and saved" do
           before do
             [:thumb, :original].each do |style|
-              object = spy
+              object = double
               allow(@dummy.avatar).to receive(:s3_object).with(style).and_return(object)
 
               expect(object).to receive(:upload_file)
@@ -1642,7 +1641,7 @@ describe Paperclip::Storage::S3 do
       context "and saved" do
         before do
           [:thumb, :original].each do |style|
-            object = spy
+            object = double
             allow(@dummy.avatar).to receive(:s3_object).with(style).and_return(object)
 
             expect(object).to receive(:upload_file)

--- a/spec/paperclip/style_spec.rb
+++ b/spec/paperclip/style_spec.rb
@@ -103,7 +103,7 @@ describe Paperclip::Style do
       @attachment = attachment path: ":basename.:extension",
                                styles: {thumb: "100x100", large: "400x400"},
                                convert_options: {all: "-do_stuff", thumb: "-thumbnailize"}
-      @attachment.expects(:extra_options_for).never
+      expect(@attachment).to_not receive(:extra_options_for)
       @style = @attachment.styles[:thumb]
     end
 
@@ -113,9 +113,9 @@ describe Paperclip::Style do
                                convert_options: {all: "-do_stuff", thumb: "-thumbnailize"}
       @style = @attachment.styles[:thumb]
       @file = StringIO.new("...")
-      @file.stubs(:original_filename).returns("file.jpg")
+      allow(@file).to receive(:original_filename).and_return("file.jpg")
 
-      @attachment.expects(:extra_options_for).with(:thumb)
+      expect(@attachment).to receive(:extra_options_for).with(:thumb)
       @attachment.styles[:thumb].convert_options
     end
   end
@@ -125,7 +125,7 @@ describe Paperclip::Style do
       @attachment = attachment path: ":basename.:extension",
                                styles: {thumb: "100x100", large: "400x400"},
                                source_file_options: {all: "-density 400", thumb: "-depth 8"}
-      @attachment.expects(:extra_source_file_options_for).never
+      expect(@attachment).to_not receive(:extra_source_file_options_for)
       @style = @attachment.styles[:thumb]
     end
 
@@ -135,9 +135,9 @@ describe Paperclip::Style do
                                source_file_options: {all: "-density 400", thumb: "-depth 8"}
       @style = @attachment.styles[:thumb]
       @file = StringIO.new("...")
-      @file.stubs(:original_filename).returns("file.jpg")
+      allow(@file).to receive(:original_filename).and_return("file.jpg")
 
-      @attachment.expects(:extra_source_file_options_for).with(:thumb)
+      expect(@attachment).to receive(:extra_source_file_options_for).with(:thumb)
       @attachment.styles[:thumb].source_file_options
     end
   end
@@ -157,7 +157,7 @@ describe Paperclip::Style do
     end
 
     it "does not get processors from the attachment" do
-      @attachment.expects(:processors).never
+      expect(@attachment).to_not receive(:processors)
       assert_not_equal [:thumbnail], @style.processors
     end
 
@@ -200,7 +200,7 @@ describe Paperclip::Style do
                                  }
                                }
       @file = StringIO.new("...")
-      @file.stubs(:original_filename).returns("file.jpg")
+      allow(@file).to receive(:original_filename).and_return("file.jpg")
     end
 
     it "has empty options for :thumb style" do

--- a/spec/paperclip/thumbnail_spec.rb
+++ b/spec/paperclip/thumbnail_spec.rb
@@ -83,7 +83,7 @@ describe Paperclip::Thumbnail do
       end
 
       it "sends the right command to convert when sent #make" do
-        @thumb.expects(:convert).with do |*arg|
+        expect(@thumb).to receive(:convert) do |*arg|
           arg[0] == ':source -auto-orient -resize "x50" -crop "100x50+114+0" +repage :dest' &&
           arg[1][:source] == "#{File.expand_path(@thumb.file.path)}[0]"
         end
@@ -118,7 +118,7 @@ describe Paperclip::Thumbnail do
       end
 
       it "sends the right command to convert when sent #make" do
-        @thumb.expects(:convert).with do |*arg|
+        expect(@thumb).to receive(:convert) do |*arg|
           arg[0] == '-strip :source -auto-orient -resize "x50" -crop "100x50+114+0" +repage :dest' &&
           arg[1][:source] == "#{File.expand_path(@thumb.file.path)}[0]"
         end
@@ -159,7 +159,7 @@ describe Paperclip::Thumbnail do
       end
 
       it "sends the right command to convert when sent #make" do
-        @thumb.expects(:convert).with do |*arg|
+        expect(@thumb).to receive(:convert) do |*arg|
           arg[0] == ':source -auto-orient -resize "x50" -crop "100x50+114+0" +repage -strip -depth 8 :dest' &&
           arg[1][:source] == "#{File.expand_path(@thumb.file.path)}[0]"
         end
@@ -221,7 +221,7 @@ describe Paperclip::Thumbnail do
     context "being thumbnailed with default animated option (true)" do
       it "calls identify to check for animated images when sent #make" do
         thumb = Paperclip::Thumbnail.new(@file, geometry: "100x50#")
-        thumb.expects(:identify).at_least_once.with do |*arg|
+        expect(thumb).to receive(:identify).at_least(1).times do |*arg|
           arg[0] == '-format %m :file' &&
           arg[1][:file] == "#{File.expand_path(thumb.file.path)}[0]"
         end

--- a/spec/paperclip/validators/attachment_content_type_validator_spec.rb
+++ b/spec/paperclip/validators/attachment_content_type_validator_spec.rb
@@ -15,7 +15,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
   context "with a nil content type" do
     before do
       build_validator content_type: "image/jpg"
-      @dummy.stubs(avatar_content_type: nil)
+      allow(@dummy).to receive_messages(avatar_content_type: nil)
       @validator.validate(@dummy)
     end
 
@@ -28,7 +28,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
     context "as true" do
       before do
         build_validator content_type: "image/png", allow_nil: true
-        @dummy.stubs(avatar_content_type: nil)
+        allow(@dummy).to receive_messages(avatar_content_type: nil)
         @validator.validate(@dummy)
       end
 
@@ -40,7 +40,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
     context "as false" do
       before do
         build_validator content_type: "image/png", allow_nil: false
-        @dummy.stubs(avatar_content_type: nil)
+        allow(@dummy).to receive_messages(avatar_content_type: nil)
         @validator.validate(@dummy)
       end
 
@@ -53,7 +53,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
   context "with a failing validation" do
     before do
       build_validator content_type: "image/png", allow_nil: false
-      @dummy.stubs(avatar_content_type: nil)
+      allow(@dummy).to receive_messages(avatar_content_type: nil)
       @validator.validate(@dummy)
     end
 
@@ -70,7 +70,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
   context "with a successful validation" do
     before do
       build_validator content_type: "image/png", allow_nil: false
-      @dummy.stubs(avatar_content_type: "image/png")
+      allow(@dummy).to receive_messages(avatar_content_type: "image/png")
       @validator.validate(@dummy)
     end
 
@@ -84,7 +84,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
     context "as true" do
       before do
         build_validator content_type: "image/png", allow_blank: true
-        @dummy.stubs(avatar_content_type: "")
+        allow(@dummy).to receive_messages(avatar_content_type: "")
         @validator.validate(@dummy)
       end
 
@@ -96,7 +96,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
     context "as false" do
       before do
         build_validator content_type: "image/png", allow_blank: false
-        @dummy.stubs(avatar_content_type: "")
+        allow(@dummy).to receive_messages(avatar_content_type: "")
         @validator.validate(@dummy)
       end
 
@@ -111,7 +111,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
       context "as a string" do
         before do
           build_validator content_type: "image/jpg"
-          @dummy.stubs(avatar_content_type: "image/jpg")
+          allow(@dummy).to receive_messages(avatar_content_type: "image/jpg")
           @validator.validate(@dummy)
         end
 
@@ -123,7 +123,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
       context "as an regexp" do
         before do
           build_validator content_type: /^image\/.*/
-          @dummy.stubs(avatar_content_type: "image/jpg")
+          allow(@dummy).to receive_messages(avatar_content_type: "image/jpg")
           @validator.validate(@dummy)
         end
 
@@ -135,7 +135,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
       context "as a list" do
         before do
           build_validator content_type: ["image/png", "image/jpg", "image/jpeg"]
-          @dummy.stubs(avatar_content_type: "image/jpg")
+          allow(@dummy).to receive_messages(avatar_content_type: "image/jpg")
           @validator.validate(@dummy)
         end
 
@@ -149,7 +149,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
       context "as a string" do
         before do
           build_validator content_type: "image/png"
-          @dummy.stubs(avatar_content_type: "image/jpg")
+          allow(@dummy).to receive_messages(avatar_content_type: "image/jpg")
           @validator.validate(@dummy)
         end
 
@@ -162,7 +162,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
       context "as a regexp" do
         before do
           build_validator content_type: /^text\/.*/
-          @dummy.stubs(avatar_content_type: "image/jpg")
+          allow(@dummy).to receive_messages(avatar_content_type: "image/jpg")
           @validator.validate(@dummy)
         end
 
@@ -176,7 +176,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
         context "without interpolation" do
           before do
             build_validator content_type: "image/png", message: "should be a PNG image"
-            @dummy.stubs(avatar_content_type: "image/jpg")
+            allow(@dummy).to receive_messages(avatar_content_type: "image/jpg")
             @validator.validate(@dummy)
           end
 
@@ -188,7 +188,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
         context "with interpolation" do
           before do
             build_validator content_type: "image/png", message: "should have content type %{types}"
-            @dummy.stubs(avatar_content_type: "image/jpg")
+            allow(@dummy).to receive_messages(avatar_content_type: "image/jpg")
             @validator.validate(@dummy)
           end
 
@@ -205,7 +205,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
       context "as a string" do
         before do
           build_validator not: "image/gif"
-          @dummy.stubs(avatar_content_type: "image/jpg")
+          allow(@dummy).to receive_messages(avatar_content_type: "image/jpg")
           @validator.validate(@dummy)
         end
 
@@ -217,7 +217,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
       context "as an regexp" do
         before do
           build_validator not: /^text\/.*/
-          @dummy.stubs(avatar_content_type: "image/jpg")
+          allow(@dummy).to receive_messages(avatar_content_type: "image/jpg")
           @validator.validate(@dummy)
         end
 
@@ -229,7 +229,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
       context "as a list" do
         before do
           build_validator not: ["image/png", "image/jpg", "image/jpeg"]
-          @dummy.stubs(avatar_content_type: "image/gif")
+          allow(@dummy).to receive_messages(avatar_content_type: "image/gif")
           @validator.validate(@dummy)
         end
 
@@ -243,7 +243,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
       context "as a string" do
         before do
           build_validator not: "image/png"
-          @dummy.stubs(avatar_content_type: "image/png")
+          allow(@dummy).to receive_messages(avatar_content_type: "image/png")
           @validator.validate(@dummy)
         end
 
@@ -256,7 +256,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
       context "as a regexp" do
         before do
           build_validator not: /^text\/.*/
-          @dummy.stubs(avatar_content_type: "text/plain")
+          allow(@dummy).to receive_messages(avatar_content_type: "text/plain")
           @validator.validate(@dummy)
         end
 
@@ -270,7 +270,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
         context "without interpolation" do
           before do
             build_validator not: "image/png", message: "should not be a PNG image"
-            @dummy.stubs(avatar_content_type: "image/png")
+            allow(@dummy).to receive_messages(avatar_content_type: "image/png")
             @validator.validate(@dummy)
           end
 
@@ -282,7 +282,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
         context "with interpolation" do
           before do
             build_validator not: "image/png", message: "should not have content type %{types}"
-            @dummy.stubs(avatar_content_type: "image/png")
+            allow(@dummy).to receive_messages(avatar_content_type: "image/png")
             @validator.validate(@dummy)
           end
 

--- a/spec/paperclip/validators/attachment_file_name_validator_spec.rb
+++ b/spec/paperclip/validators/attachment_file_name_validator_spec.rb
@@ -15,7 +15,7 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
   context "with a failing validation" do
     before do
       build_validator matches: /.*\.png$/, allow_nil: false
-      @dummy.stubs(avatar_file_name: "data.txt")
+      allow(@dummy).to receive_messages(avatar_file_name: "data.txt")
       @validator.validate(@dummy)
     end
 
@@ -31,7 +31,7 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
 
   it "does not add error to the base object with a successful validation" do
     build_validator matches: /.*\.png$/, allow_nil: false
-    @dummy.stubs(avatar_file_name: "image.png")
+    allow(@dummy).to receive_messages(avatar_file_name: "image.png")
     @validator.validate(@dummy)
 
     assert @dummy.errors[:avatar].blank?, "Error was added to base attribute"
@@ -42,7 +42,7 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
       context "as a single regexp" do
         before do
           build_validator matches: /.*\.jpg$/
-          @dummy.stubs(avatar_file_name: "image.jpg")
+          allow(@dummy).to receive_messages(avatar_file_name: "image.jpg")
           @validator.validate(@dummy)
         end
 
@@ -54,7 +54,7 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
       context "as a list" do
         before do
           build_validator matches: [/.*\.png$/, /.*\.jpe?g$/]
-          @dummy.stubs(avatar_file_name: "image.jpg")
+          allow(@dummy).to receive_messages(avatar_file_name: "image.jpg")
           @validator.validate(@dummy)
         end
 
@@ -67,7 +67,7 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
     context "with a disallowed type" do
       it "sets a correct default error message" do
         build_validator matches: /^text\/.*/
-        @dummy.stubs(avatar_file_name: "image.jpg")
+        allow(@dummy).to receive_messages(avatar_file_name: "image.jpg")
         @validator.validate(@dummy)
 
         assert @dummy.errors[:avatar_file_name].present?
@@ -76,7 +76,7 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
 
       it "sets a correct custom error message" do
         build_validator matches: /.*\.png$/, message: "should be a PNG image"
-        @dummy.stubs(avatar_file_name: "image.jpg")
+        allow(@dummy).to receive_messages(avatar_file_name: "image.jpg")
         @validator.validate(@dummy)
 
         expect(@dummy.errors[:avatar_file_name]).to include "should be a PNG image"
@@ -89,7 +89,7 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
       context "as a single regexp" do
         before do
           build_validator not: /^text\/.*/
-          @dummy.stubs(avatar_file_name: "image.jpg")
+          allow(@dummy).to receive_messages(avatar_file_name: "image.jpg")
           @validator.validate(@dummy)
         end
 
@@ -101,7 +101,7 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
       context "as a list" do
         before do
           build_validator not: [/.*\.png$/, /.*\.jpe?g$/]
-          @dummy.stubs(avatar_file_name: "image.gif")
+          allow(@dummy).to receive_messages(avatar_file_name: "image.gif")
           @validator.validate(@dummy)
         end
 
@@ -114,7 +114,7 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
     context "with a disallowed type" do
       it "sets a correct default error message" do
         build_validator not: /data.*/
-        @dummy.stubs(avatar_file_name: "data.txt")
+        allow(@dummy).to receive_messages(avatar_file_name: "data.txt")
         @validator.validate(@dummy)
 
         assert @dummy.errors[:avatar_file_name].present?
@@ -123,7 +123,7 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
 
       it "sets a correct custom error message" do
         build_validator not: /.*\.png$/, message: "should not be a PNG image"
-        @dummy.stubs(avatar_file_name: "image.png")
+        allow(@dummy).to receive_messages(avatar_file_name: "image.png")
         @validator.validate(@dummy)
 
         expect(@dummy.errors[:avatar_file_name]).to include "should not be a PNG image"
@@ -157,4 +157,3 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
     end
   end
 end
-

--- a/spec/paperclip/validators/attachment_size_validator_spec.rb
+++ b/spec/paperclip/validators/attachment_size_validator_spec.rb
@@ -15,7 +15,7 @@ describe Paperclip::Validators::AttachmentSizeValidator do
   def self.should_allow_attachment_file_size(size)
     context "when the attachment size is #{size}" do
       it "adds error to dummy object" do
-        @dummy.stubs(:avatar_file_size).returns(size)
+        allow(@dummy).to receive(:avatar_content_type).and_return(size)
         @validator.validate(@dummy)
         assert @dummy.errors[:avatar_file_size].blank?,
           "Expect an error message on :avatar_file_size, got none."
@@ -31,7 +31,7 @@ describe Paperclip::Validators::AttachmentSizeValidator do
   def self.should_not_allow_attachment_file_size(size, options = {})
     context "when the attachment size is #{size}" do
       before do
-        @dummy.stubs(:avatar_file_size).returns(size)
+        allow(@dummy).to receive(:avatar_file_size).and_return(size)
         @validator.validate(@dummy)
       end
 

--- a/spec/paperclip/validators/media_type_spoof_detection_validator_spec.rb
+++ b/spec/paperclip/validators/media_type_spoof_detection_validator_spec.rb
@@ -26,7 +26,7 @@ describe Paperclip::Validators::MediaTypeSpoofDetectionValidator do
     file = File.new(fixture_file("5k.png"), "rb")
     @dummy.avatar.assign(file)
 
-    detector = spy("detector", :spoofed? => true)
+    detector = double("detector", spoofed?: true)
     allow(Paperclip::MediaTypeSpoofDetector).to receive(:using).and_return(detector)
     @validator.validate(@dummy)
 
@@ -37,7 +37,7 @@ describe Paperclip::Validators::MediaTypeSpoofDetectionValidator do
     build_validator
     file = File.new(fixture_file("5k.png"), "rb")
     @dummy.avatar.assign(file)
-    expect(Paperclip::MediaTypeSpoofDetector).to receive(:using).once.and_return(spy("detector", :spoofed? => false))
+    expect(Paperclip::MediaTypeSpoofDetector).to receive(:using).once.and_return(double("detector", spoofed?: false))
     @dummy.valid?
   end
 

--- a/spec/paperclip/validators/media_type_spoof_detection_validator_spec.rb
+++ b/spec/paperclip/validators/media_type_spoof_detection_validator_spec.rb
@@ -26,7 +26,7 @@ describe Paperclip::Validators::MediaTypeSpoofDetectionValidator do
     file = File.new(fixture_file("5k.png"), "rb")
     @dummy.avatar.assign(file)
 
-    detector = double("detector", :spoofed? => true)
+    detector = spy("detector", :spoofed? => true)
     allow(Paperclip::MediaTypeSpoofDetector).to receive(:using).and_return(detector)
     @validator.validate(@dummy)
 
@@ -37,7 +37,7 @@ describe Paperclip::Validators::MediaTypeSpoofDetectionValidator do
     build_validator
     file = File.new(fixture_file("5k.png"), "rb")
     @dummy.avatar.assign(file)
-    expect(Paperclip::MediaTypeSpoofDetector).to receive(:using).once.and_return(double("detector", :spoofed? => false))
+    expect(Paperclip::MediaTypeSpoofDetector).to receive(:using).once.and_return(spy("detector", :spoofed? => false))
     @dummy.valid?
   end
 


### PR DESCRIPTION
Files to be updated:

- [x] attachment_definitions_spec.rb
- [x] attachment_processing_spec.rb
- [x] attachment_registry_spec.rb
- [x] attachment_spec.rb
- [x] content_type_detector_spec.rb
- [x] file_command_content_type_detector_spec.rb
- [x] filename_cleaner_spec.rb
- [x] geometry_detector_spec.rb
- [x] geometry_parser_spec.rb
- [x] geometry_spec.rb
- [x] glue_spec.rb
- [x] has_attached_file_spec.rb
- [x] integration_spec.rb
- [x] interpolations_spec.rb
- [x] io_adapters
- [x] │   abstract_adapter_spec.rb
- [x] │   attachment_adapter_spec.rb
- [x] │   data_uri_adapter_spec.rb
- [x] │   empty_string_adapter_spec.rb
- [x] │   file_adapter_spec.rb
- [x] │   http_url_proxy_adapter_spec.rb
- [x] │   identity_adapter_spec.rb
- [x] │   nil_adapter_spec.rb
- [x] │   registry_spec.rb
- [x] │   stringio_adapter_spec.rb
- [x] │   uploaded_file_adapter_spec.rb
- [x] │   uri_adapter_spec.rb
- [x] matchers
- [x] │   have_attached_file_matcher_spec.rb
- [x] │   validate_attachment_content_type_matcher_spec.rb
- [x] │   validate_attachment_presence_matcher_spec.rb
- [x] │   validate_attachment_size_matcher_spec.rb
- [x] media_type_spoof_detector_spec.rb
- [x] meta_class_spec.rb
- [x] paperclip_missing_attachment_styles_spec.rb
- [x] paperclip_spec.rb
- [x] plural_cache_spec.rb
- [x] processor_helpers_spec.rb
- [x] processor_spec.rb
- [x] rails_environment_spec.rb
- [x] rake_spec.rb
- [x] schema_spec.rb
- [x] storage
- [x] │   filesystem_spec.rb
- [x] │   fog_spec.rb
- [x] │   s3_live_spec.rb
- [x] │   s3_spec.rb
- [x] style_spec.rb
- [x] tempfile_factory_spec.rb
- [x] tempfile_spec.rb
- [x] thumbnail_spec.rb
- [x] url_generator_spec.rb
- [x] validators
- [x] │   attachment_content_type_validator_spec.rb
- [x] │   attachment_file_name_validator_spec.rb
- [x] │   attachment_presence_validator_spec.rb
- [x] │   attachment_size_validator_spec.rb
- [x] │   media_type_spoof_detection_validator_spec.rb
- [x] validators_spec.rb