### PR TITLE
bind sprockets to v3.7.2 for fixing cucumber specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ rvm:
   - 2.2
   - 2.3
   - 2.4
+  - 2.5
+  - 2.6
 
 script: "bundle exec rake clean spec cucumber"
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,5 @@ group :development, :test do
   gem 'builder'
   gem 'rubocop', require: false
   gem 'rspec'
+  gem 'sprockets', '3.7.2'
 end

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -12,6 +12,7 @@ group :development, :test do
   gem "builder"
   gem "rubocop", require: false
   gem "rspec"
+  gem "sprockets", "3.7.2"
 end
 
 gemspec path: "../"

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -12,6 +12,7 @@ group :development, :test do
   gem "builder"
   gem "rubocop", require: false
   gem "rspec"
+  gem "sprockets", "3.7.2"
 end
 
 gemspec path: "../"


### PR DESCRIPTION
bind sprockets to v3.7.2 because of https://github.com/rails/sprockets-rails/issues/444, 
rails 4.2 by default does require 'rails/all'