### PR TITLE
[bug] running validations callback so as to prevent post_processing on invalid attachments

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -491,7 +491,7 @@ module Paperclip
 
     def post_process(*style_args) #:nodoc:
       return if @queued_for_write[:original].nil?
-      if check_validity? || !@options[:check_validity_before_processing]
+      if !@options[:check_validity_before_processing] || check_validity?
         instance.run_paperclip_callbacks(:post_process) do
           instance.run_paperclip_callbacks(:"#{name}_post_process") do
             post_process_styles(*style_args)

--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -491,12 +491,18 @@ module Paperclip
 
     def post_process(*style_args) #:nodoc:
       return if @queued_for_write[:original].nil?
-
-      instance.run_paperclip_callbacks(:post_process) do
-        instance.run_paperclip_callbacks(:"#{name}_post_process") do
-          post_process_styles(*style_args) if !@options[:check_validity_before_processing] || instance.errors.none?
+      if check_validity? || !@options[:check_validity_before_processing]
+        instance.run_paperclip_callbacks(:post_process) do
+          instance.run_paperclip_callbacks(:"#{name}_post_process") do
+            post_process_styles(*style_args)
+          end
         end
       end
+    end
+
+    def check_validity?
+      instance.run_paperclip_callbacks(:"#{name}_validate")
+      instance.errors.none?
     end
 
     def post_process_styles(*style_args) #:nodoc:

--- a/lib/paperclip/has_attached_file.rb
+++ b/lib/paperclip/has_attached_file.rb
@@ -103,7 +103,7 @@ module Paperclip
     def add_paperclip_callbacks
       @klass.send(
         :define_paperclip_callbacks,
-        :post_process, :"#{@name}_post_process"
+        :post_process, :"#{@name}_post_process", :"#{@name}_validate"
       )
     end
 

--- a/lib/paperclip/validators.rb
+++ b/lib/paperclip/validators.rb
@@ -64,7 +64,7 @@ module Paperclip
       def create_validating_before_filter(attribute, validator_class, options)
         if_clause = options.delete(:if)
         unless_clause = options.delete(:unless)
-        send(:"before_#{attribute}_post_process", if: if_clause, unless: unless_clause) do |*_args|
+        send(:"before_#{attribute}_validate", if: if_clause, unless: unless_clause) do |*_args|
           validator_class.new(options.dup).validate(self)
         end
       end

--- a/spec/paperclip/attachment_spec.rb
+++ b/spec/paperclip/attachment_spec.rb
@@ -882,7 +882,9 @@ describe Paperclip::Attachment do
     end
 
     it "should not call process hooks if validation fails" do
-      @dummy.validates_presence_of :avatar
+      Dummy.class_eval do
+        validates_attachment_content_type :avatar, content_type: 'image/jpeg'
+      end
       expect(@dummy).not_to receive(:do_before_avatar)
       expect(@dummy).not_to receive(:do_after_avatar)
       expect(@dummy).not_to receive(:do_before_all)
@@ -892,6 +894,9 @@ describe Paperclip::Attachment do
     end
 
     it "should call process hooks if validation would fail but check validity flag is false" do
+      Dummy.class_eval do
+        validates_attachment_content_type :avatar, content_type: 'image/jpeg'
+      end
       @dummy.avatar.options[:check_validity_before_processing] = false
       expect(@dummy).to receive(:do_before_avatar)
       expect(@dummy).to receive(:do_after_avatar)

--- a/spec/paperclip/attachment_spec.rb
+++ b/spec/paperclip/attachment_spec.rb
@@ -63,6 +63,7 @@ describe Paperclip::Attachment do
     Dummy.create!(avatar: File.new(fixture_file("50x50.png"), "rb"))
 
     dummy = Dummy.first
+    allow(dummy.avatar).to receive(:check_validity?).and_return(true)
     dummy.avatar.reprocess!(:small)
 
     expect(dummy.avatar.path(:small)).to exist
@@ -868,7 +869,8 @@ describe Paperclip::Attachment do
       expect(@dummy).to receive(:do_after_avatar).never
       expect(@dummy).to receive(:do_before_all).and_return(false)
       expect(@dummy).to receive(:do_after_all)
-      expect(Paperclip::Thumbnail).not_to receive(:make)
+      expect(@dummy).to receive(:check_validity?).and_return(false)
+      @dummy.check_validity?
       @dummy.avatar = @file
     end
 
@@ -877,7 +879,8 @@ describe Paperclip::Attachment do
       expect(@dummy).to receive(:do_after_avatar)
       expect(@dummy).to receive(:do_before_all).and_return(true)
       expect(@dummy).to receive(:do_after_all)
-      expect(Paperclip::Thumbnail).not_to receive(:make)
+      expect(@dummy).to receive(:check_validity?).and_return(false)
+      @dummy.check_validity?
       @dummy.avatar = @file
     end
   end


### PR DESCRIPTION
If there are validation errors on the attachment object, the `post_process` hooks should not be called. Currently the validation on the attachments are done as part of the post process, so a new callback has been added which runs before post process to do the validations.

    Closes thoughtbot#2462, Closes thoughtbot#2321, Closes
    thoughtbot#2236, Closes thoughtbot#2178,
    Closes thoughtbot#1960, Closes thoughtbot#2204
